### PR TITLE
fix: handle dark_color alpha in spine shader

### DIFF
--- a/src/spine.wgsl
+++ b/src/spine.wgsl
@@ -37,6 +37,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     out.position = mesh_functions::mesh2d_position_world_to_clip(out.world_position);
     out.world_normal = mesh_functions::mesh2d_normal_local_to_world(vertex.normal, vertex.instance_index);
     out.color = vertex.color;
+    out.dark_color = vertex.dark_color;
     return out;
 }
 
@@ -51,7 +52,7 @@ fn fragment(
 ) -> @location(0) vec4<f32> {
     let tex_color = textureSample(texture, texture_sampler, input.uv);
     var color = vec4(
-        ((tex_color.a - 1.0) * input.dark_color.a + 1.0 - tex_color.rgb) * input.dark_color.rgb + tex_color.rgb * input.color.rgb,
+        ((tex_color.a - 1.0) * input.dark_color.a + 1.0 - tex_color.rgb) * (input.dark_color.rgb * input.color.a) + tex_color.rgb * input.color.rgb,
         tex_color.a * input.color.a,
     );
 #ifdef TONEMAP_IN_SHADER


### PR DESCRIPTION
# Fix for Spine Dark Tint Rendering #18
Dark Tint Color (when set) is always shown because the Spine uses the primary color's alpha as the alpha for everything.  The shader was not multiplying the dark RGB by the primary's Alpha, causing dark tint to be rendered when it shouldn't be.

This was found by digging through the Unity shaders in the official spine-runtime [here](https://github.com/EsotericSoftware/spine-runtimes/blob/3b8069f4b91cc05329147c372446cd5b54e0f5dd/spine-unity/Assets/Spine/Runtime/spine-unity/Shaders/CGIncludes/Spine-Skeleton-Tint-Common.cginc#L4)