### PR TITLE
Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ exclude = ["assets/*"]
 
 [dependencies]
 rusty_spine = "0.8"
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_render",
     "bevy_asset",
     "bevy_sprite",
 ] }
-glam = { version = "0.27", features = ["mint"] }
+glam = { version = "0.29", features = ["mint"] }
 thiserror = "1.0.50"
 
 [dev-dependencies]
 lerp = "0.5"
-bevy = { version = "0.14", default-features = true }
+bevy = { version = "0.15", default-features = true }
 
 [workspace]
 resolver = "2"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_spine::{
-    SkeletonController, SkeletonData, Spine, SpineBundle, SpinePlugin, SpineReadyEvent, SpineSet,
+    SkeletonController, SkeletonData, Spine, SpineBundle, SpineLoader, SpinePlugin, SpineReadyEvent, SpineSet
 };
 
 fn main() {
@@ -16,7 +16,7 @@ fn setup(
     mut commands: Commands,
     mut skeletons: ResMut<Assets<SkeletonData>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let skeleton = SkeletonData::new_from_json(
         asset_server.load("spineboy/export/spineboy-pro.json"),
@@ -25,7 +25,10 @@ fn setup(
     let skeleton_handle = skeletons.add(skeleton);
 
     commands.spawn(SpineBundle {
-        skeleton: skeleton_handle.clone(),
+        loader: SpineLoader {
+            skeleton: skeleton_handle.clone(),
+            with_children: true,
+        },
         transform: Transform::from_xyz(0., -200., 0.),
         ..Default::default()
     });

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.83.0"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -32,11 +32,11 @@ impl AssetLoader for AtlasLoader {
     type Settings = ();
     type Error = SpineLoaderError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader<'_>,
-        _settings: &'a Self::Settings,
-        load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
@@ -72,11 +72,11 @@ impl AssetLoader for SkeletonJsonLoader {
     type Settings = ();
     type Error = SpineLoaderError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader<'_>,
-        _settings: &'a Self::Settings,
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
@@ -106,11 +106,11 @@ impl AssetLoader for SkeletonBinaryLoader {
     type Settings = ();
     type Error = SpineLoaderError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader<'_>,
-        _settings: &'a Self::Settings,
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;


### PR DESCRIPTION
Throwing this PR up asap to track changes.

Migration seems pretty straightforward, but the API is going to change with the introduction of required components, and the removal of asset handles as components. `SpineBundle` will no longer be the way to spawn skeletons, and I think that role needs to go to the SpineLoader component. It's a bit more transparent to the user, this way, anyway.

Also `SpineMaterial` might need a separate 2d and 3d implementation due to the `MeshMaterial2d` and `MeshMaterial3d` split.