### PR TITLE
Rename SpineMaterial to SpineMaterial2d and add SpineMaterial3d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ exclude = ["assets/*"]
 
 [dependencies]
 rusty_spine = "0.8"
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_render",
     "bevy_asset",
     "bevy_sprite",
 ] }
-glam = { version = "0.27", features = ["mint"] }
+glam = { version = "0.29", features = ["mint"] }
 thiserror = "1.0.50"
 
 [dev-dependencies]
 lerp = "0.5"
-bevy = { version = "0.14", default-features = true }
+bevy = { version = "0.15", default-features = true }
 
 [workspace]
 resolver = "2"

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -5,7 +5,7 @@ use bevy::{
     window::{CursorGrabMode, PrimaryWindow},
 };
 use bevy_spine::{
-    materials::{SpineMaterial, SpineMaterialInfo, SpineMaterialPlugin, SpineSettingsQuery},
+    materials::{Spine3dSettingsQuery, SpineMaterial3d, SpineMaterialInfo, SpineMaterialPlugin3d},
     prelude::*,
     SpineMeshType,
 };
@@ -30,7 +30,7 @@ fn main() {
         .add_plugins((
             DefaultPlugins,
             SpinePlugin,
-            SpineMaterialPlugin::<Spine3DMaterial>::default(),
+            SpineMaterialPlugin3d::<Spine3DMaterial>::default(),
         ))
         .add_systems(Startup, setup)
         .add_systems(Update, (on_spawn.in_set(SpineSet::OnReady), controls))
@@ -45,29 +45,27 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // plane
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Plane3d::default().mesh().size(5.0, 5.0)),
-        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
-        ..default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+    ));
 
     // light
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
-            intensity: 1500.0,
+    commands.spawn((
+        DirectionalLight {
             shadows_enabled: true,
+            shadow_depth_bias: 0.05,
+            shadow_normal_bias: 0.05,
+            illuminance: 5_800.0,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..default()
-    });
+        Transform::from_xyz(0.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 
     // camera
     commands.spawn((
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        Camera3d::default(),
+        Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
         Orbit::default(),
     ));
 
@@ -77,8 +75,11 @@ fn setup(
         asset_server.load("spineboy/export/spineboy-pma.atlas"),
     );
     let skeleton_handle = skeletons.add(skeleton);
-    commands.spawn(SpineBundle {
-        skeleton: skeleton_handle.clone(),
+    commands.spawn((SpineBundle {
+        loader: SpineLoader {
+            skeleton: skeleton_handle.clone(),
+            ..Default::default()
+        },
         transform: Transform::from_xyz(0., 0., 0.).with_scale(Vec3::ONE * 0.005),
         settings: SpineSettings {
             default_materials: false,
@@ -86,7 +87,7 @@ fn setup(
             ..Default::default()
         },
         ..Default::default()
-    });
+    },));
 }
 
 fn on_spawn(
@@ -110,37 +111,39 @@ fn controls(
     mouse_buttons: Res<ButtonInput<MouseButton>>,
     keys: Res<ButtonInput<KeyCode>>,
 ) {
-    let mut window = window_query.single_mut();
-    if mouse_buttons.just_pressed(MouseButton::Left) {
-        window.cursor.grab_mode = CursorGrabMode::Locked;
-        window.cursor.visible = false;
-    }
-    if keys.just_pressed(KeyCode::Escape) {
-        window.cursor.grab_mode = CursorGrabMode::None;
-        window.cursor.visible = true;
-    }
-
-    let mut mouse_movement = Vec2::ZERO;
-    for mouse_motion_event in mouse_motion_events.read() {
-        if window.cursor.grab_mode == CursorGrabMode::Locked {
-            mouse_movement += mouse_motion_event.delta;
+    let window = window_query.get_single_mut();
+    if let Ok(mut window) = window {
+        if mouse_buttons.just_pressed(MouseButton::Left) {
+            window.cursor_options.grab_mode = CursorGrabMode::Locked;
+            window.cursor_options.visible = false;
         }
-    }
-    for (mut orbit, mut orbit_transform) in orbit_query.iter_mut() {
-        orbit.angle = (orbit.angle + mouse_movement.x * 0.001).clamp(0.14159, 3.);
-        orbit.pitch = (orbit.pitch + mouse_movement.y * 0.001).clamp(0.1, 1.5);
-        orbit_transform.translation =
-            Vec3::new(orbit.angle.cos(), orbit.pitch.tan(), orbit.angle.sin()).normalize() * 7.;
-        orbit_transform.look_at(Vec3::new(0., 1.5, 0.), Vec3::Y);
+        if keys.just_pressed(KeyCode::Escape) {
+            window.cursor_options.grab_mode = CursorGrabMode::None;
+            window.cursor_options.visible = true;
+        }
+
+        let mut mouse_movement = Vec2::ZERO;
+        for mouse_motion_event in mouse_motion_events.read() {
+            if window.cursor_options.grab_mode == CursorGrabMode::Locked {
+                mouse_movement += mouse_motion_event.delta;
+            }
+        }
+        for (mut orbit, mut orbit_transform) in orbit_query.iter_mut() {
+            orbit.angle = (orbit.angle + mouse_movement.x * 0.001).clamp(0.14159, 3.);
+            orbit.pitch = (orbit.pitch + mouse_movement.y * 0.001).clamp(0.1, 1.5);
+            orbit_transform.translation =
+                Vec3::new(orbit.angle.cos(), orbit.pitch.tan(), orbit.angle.sin()).normalize() * 7.;
+            orbit_transform.look_at(Vec3::new(0., 1.5, 0.), Vec3::Y);
+        }
     }
 }
 
 #[derive(Component)]
 pub struct Spine3DMaterial;
 
-impl SpineMaterial for Spine3DMaterial {
+impl SpineMaterial3d for Spine3DMaterial {
     type Material = StandardMaterial;
-    type Params<'w, 's> = SpineSettingsQuery<'w, 's>;
+    type Params<'w, 's> = Spine3dSettingsQuery<'w, 's>;
 
     fn update(
         material: Option<Self::Material>,
@@ -155,15 +158,12 @@ impl SpineMaterial for Spine3DMaterial {
             .unwrap_or(SpineSettings::default());
         if spine_settings.mesh_type == SpineMeshType::Mesh3D {
             let mut material = material.unwrap_or_else(|| Self::Material {
-                unlit: true,
-                alpha_mode: if renderable_data.premultiplied_alpha {
-                    AlphaMode::Premultiplied
-                } else {
-                    AlphaMode::Blend
-                },
                 ..Self::Material::default()
             });
+            material.base_color = Color::srgba(1.0, 1.0, 1.0, 1.0);
             material.base_color_texture = Some(renderable_data.texture);
+            material.alpha_mode = AlphaMode::Blend;
+            material.unlit = true;
             Some(material)
         } else {
             None

--- a/examples/crossfades.rs
+++ b/examples/crossfades.rs
@@ -1,8 +1,5 @@
 use bevy::prelude::*;
-use bevy_spine::{
-    Crossfades, SkeletonController, SkeletonData, Spine, SpineBundle, SpinePlugin, SpineReadyEvent,
-    SpineSet, SpineSystem,
-};
+use bevy_spine::prelude::*;
 
 fn main() {
     App::new()
@@ -23,7 +20,7 @@ fn setup(
     mut commands: Commands,
     mut skeletons: ResMut<Assets<SkeletonData>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let skeleton = SkeletonData::new_from_json(
         asset_server.load("spineboy/export/spineboy-pro.json"),
@@ -35,14 +32,17 @@ fn setup(
     crossfades.add("idle", "walk", 0.5);
     crossfades.add("walk", "idle", 0.5);
 
-    commands.spawn(SpineBundle {
-        skeleton: skeleton_handle.clone(),
+    commands.spawn((SpineBundle {
+        loader: SpineLoader {
+            skeleton: skeleton_handle.clone(),
+            ..Default::default()
+        },
         crossfades,
         transform: Transform::default()
             .with_translation(Vec3::new(0., -200., 0.))
             .with_scale(Vec3::ONE * 0.5),
         ..Default::default()
-    });
+    },));
 }
 
 fn on_spawn(
@@ -68,7 +68,7 @@ fn crossfades(mut spine_query: Query<&mut Spine>, time: Res<Time>) {
             .animation()
             .name()
             .to_owned();
-        if time.elapsed_seconds() % 2. > 1. {
+        if time.elapsed_secs() % 2. > 1. {
             if current_animation != "walk" {
                 let _ = spine.animation_state.set_animation_by_name(0, "walk", true);
             }

--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -12,11 +12,11 @@ use bevy::{
 };
 use bevy_spine::{
     materials::{
-        SpineMaterial, SpineMaterialInfo, SpineMaterialPlugin, DARK_COLOR_ATTRIBUTE,
+        SpineMaterial2d, SpineMaterialInfo, SpineMaterialPlugin, DARK_COLOR_ATTRIBUTE,
         DARK_COLOR_SHADER_POSITION,
     },
-    SkeletonController, SkeletonData, Spine, SpineBundle, SpineDrawer, SpinePlugin,
-    SpineReadyEvent, SpineSet, SpineSettings,
+    prelude::*,
+    SpineDrawer,
 };
 
 fn main() {
@@ -37,7 +37,7 @@ fn setup(
     mut commands: Commands,
     mut skeletons: ResMut<Assets<SkeletonData>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let skeleton = SkeletonData::new_from_json(
         asset_server.load("spineboy/export/spineboy-pro.json"),
@@ -47,7 +47,10 @@ fn setup(
 
     // Spine with no custom materials
     commands.spawn((SpineBundle {
-        skeleton: skeleton_handle.clone(),
+        loader: SpineLoader {
+            skeleton: skeleton_handle.clone(),
+            ..Default::default()
+        },
         transform: Transform::from_xyz(-230., -130., 0.).with_scale(Vec3::ONE * 0.375),
         ..Default::default()
     },));
@@ -55,7 +58,10 @@ fn setup(
     // Spine with custom materials
     commands.spawn((
         SpineBundle {
-            skeleton: skeleton_handle.clone(),
+            loader: SpineLoader {
+                skeleton: skeleton_handle.clone(),
+                ..Default::default()
+            },
             transform: Transform::from_xyz(230., -130., 0.).with_scale(Vec3::ONE * 0.375),
             settings: SpineSettings {
                 default_materials: false,
@@ -128,7 +134,7 @@ pub struct MyMaterialParam<'w, 's> {
     time: Res<'w, Time>,
 }
 
-impl SpineMaterial for MyMaterial {
+impl SpineMaterial2d for MyMaterial {
     type Material = Self;
     type Params<'w, 's> = MyMaterialParam<'w, 's>;
 
@@ -141,7 +147,7 @@ impl SpineMaterial for MyMaterial {
         if let Ok(spine) = params.my_spine_query.get(entity) {
             let mut material = material.unwrap_or_default();
             material.image = renderable_data.texture;
-            material.time = params.time.elapsed_seconds();
+            material.time = params.time.elapsed_secs();
             if let Some(slot) = spine
                 .skeleton
                 .slot_at_index(renderable_data.slot_index.unwrap_or(9999))

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,8 +1,5 @@
 use bevy::prelude::*;
-use bevy_spine::{
-    SkeletonController, SkeletonData, Spine, SpineBundle, SpineEvent, SpinePlugin, SpineReadyEvent,
-    SpineSet,
-};
+use bevy_spine::prelude::*;
 
 fn main() {
     App::new()
@@ -24,7 +21,7 @@ fn setup(
     mut commands: Commands,
     mut skeletons: ResMut<Assets<SkeletonData>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let skeleton = SkeletonData::new_from_json(
         asset_server.load("spineboy/export/spineboy-pro.json"),
@@ -32,11 +29,14 @@ fn setup(
     );
     let skeleton_handle = skeletons.add(skeleton);
 
-    commands.spawn(SpineBundle {
-        skeleton: skeleton_handle.clone(),
+    commands.spawn((SpineBundle {
+        loader: SpineLoader {
+            skeleton: skeleton_handle.clone(),
+            ..Default::default()
+        },
         transform: Transform::from_xyz(0., -200., 0.).with_scale(Vec3::ONE * 0.5),
         ..Default::default()
-    });
+    },));
 }
 
 fn on_spawn(
@@ -61,19 +61,17 @@ fn on_spine_event(
     for event in spine_events.read() {
         if let SpineEvent::Event { name, .. } = event {
             commands
-                .spawn(Text2dBundle {
-                    text: Text::from_section(
-                        name.as_str(),
-                        TextStyle {
-                            font: asset_server.load("FiraMono-Medium.ttf"),
-                            font_size: 22.0,
-                            color: Color::WHITE,
-                        },
-                    )
-                    .with_justify(JustifyText::Center),
-                    transform: Transform::from_xyz(0., -200., 1.),
-                    ..Default::default()
-                })
+                .spawn((
+                    Text2d(name.clone()),
+                    TextFont {
+                        font: asset_server.load("FiraMono-Medium.ttf"),
+                        font_size: 22.0,
+                        ..Default::default()
+                    },
+                    TextColor(Color::WHITE),
+                    Transform::from_xyz(0., -200., 1.),
+                    TextLayout::new_with_justify(JustifyText::Center),
+                ))
                 .insert(Footstep);
         }
     }
@@ -83,15 +81,15 @@ fn on_spine_event(
 struct Footstep;
 
 fn footstep_update(
-    mut footstep_query: Query<(&mut Transform, &mut Text, Entity), With<Footstep>>,
+    mut footstep_query: Query<(&mut Transform, &mut TextColor, Entity), With<Footstep>>,
     mut commands: Commands,
     time: Res<Time>,
 ) {
-    for (mut transform, mut text, entity) in footstep_query.iter_mut() {
-        transform.translation.y += time.delta_seconds() * 70.;
-        let mut alpha = text.sections[0].style.color.alpha();
-        alpha = (alpha - time.delta_seconds() * 2.).clamp(0., 1.);
-        text.sections[0].style.color.set_alpha(alpha);
+    for (mut transform, mut text_color, entity) in footstep_query.iter_mut() {
+        transform.translation.y += time.delta_secs() * 70.;
+        let mut alpha = text_color.0.alpha();
+        alpha = (alpha - time.delta_secs() * 2.).clamp(0., 1.);
+        text_color.0.set_alpha(alpha);
         if alpha == 0. {
             commands.entity(entity).despawn();
         }

--- a/examples/immediate_spawn.rs
+++ b/examples/immediate_spawn.rs
@@ -1,9 +1,7 @@
 //! Demonstrates how to spawn a [`SpineBundle`] and use it in one frame.
 
 use bevy::{app::AppExit, core::FrameCount, prelude::*};
-use bevy_spine::{
-    SkeletonData, Spine, SpineBundle, SpinePlugin, SpineReadyEvent, SpineSet, SpineSystem,
-};
+use bevy_spine::prelude::*;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum ExampleSet {
@@ -40,7 +38,7 @@ fn setup(
     mut skeletons: ResMut<Assets<SkeletonData>>,
     mut demo_data: ResMut<DemoData>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let skeleton = SkeletonData::new_from_json(
         asset_server.load("spineboy/export/spineboy-pro.json"),
@@ -58,11 +56,14 @@ fn spawn(
     if !demo_data.spawned {
         if let Some(skeleton) = skeletons.get(&demo_data.skeleton_handle) {
             if skeleton.is_loaded() {
-                commands.spawn(SpineBundle {
-                    skeleton: demo_data.skeleton_handle.clone(),
+                commands.spawn((SpineBundle {
+                    loader: SpineLoader {
+                        skeleton: demo_data.skeleton_handle.clone(),
+                        ..Default::default()
+                    },
                     transform: Transform::from_xyz(0., -200., 0.).with_scale(Vec3::ONE * 0.5),
                     ..Default::default()
-                });
+                },));
                 demo_data.spawned = true;
                 println!("spawned on frame: {}", frame_count.0);
             }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_spine::{
-    SkeletonController, SkeletonData, Spine, SpineBundle, SpinePlugin, SpineReadyEvent, SpineSet,
+    SkeletonController, SkeletonData, Spine, SpineBundle, SpineLoader, SpinePlugin, SpineReadyEvent, SpineSet
 };
 
 fn main() {
@@ -16,7 +16,7 @@ fn setup(
     mut commands: Commands,
     mut skeletons: ResMut<Assets<SkeletonData>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let skeleton = SkeletonData::new_from_json(
         asset_server.load("spineboy/export/spineboy-pro.json"),
@@ -25,7 +25,10 @@ fn setup(
     let skeleton_handle = skeletons.add(skeleton);
 
     commands.spawn(SpineBundle {
-        skeleton: skeleton_handle.clone(),
+        loader: SpineLoader {
+            skeleton: skeleton_handle.clone(),
+            with_children: true,
+        },
         transform: Transform::from_xyz(0., -200., 0.),
         ..Default::default()
     });

--- a/examples/spineboy/bullet.rs
+++ b/examples/spineboy/bullet.rs
@@ -36,15 +36,14 @@ pub struct Bullet {
 fn bullet_spawn(mut commands: Commands, mut bullet_spawn_events: EventReader<BulletSpawnEvent>) {
     for event in bullet_spawn_events.read() {
         commands
-            .spawn(SpriteBundle {
-                sprite: Sprite {
+            .spawn((
+                Sprite {
                     color: Srgba::RED.into(),
                     custom_size: Some(Vec2::ONE * 16.),
                     ..Default::default()
                 },
-                transform: Transform::from_translation(event.position.extend(1.)),
-                ..Default::default()
-            })
+                Transform::from_translation(event.position.extend(1.)),
+            ))
             .insert(Bullet {
                 velocity: event.velocity,
             });
@@ -53,6 +52,6 @@ fn bullet_spawn(mut commands: Commands, mut bullet_spawn_events: EventReader<Bul
 
 fn bullet_update(mut bullet_query: Query<(&mut Transform, &Bullet)>, time: Res<Time>) {
     for (mut bullet_transform, bullet) in bullet_query.iter_mut() {
-        bullet_transform.translation += (bullet.velocity * time.delta_seconds()).extend(0.);
+        bullet_transform.translation += (bullet.velocity * time.delta_secs()).extend(0.);
     }
 }

--- a/examples/spineboy/main.rs
+++ b/examples/spineboy/main.rs
@@ -16,7 +16,7 @@ fn setup(
     mut player_spawn_events: EventWriter<PlayerSpawnEvent>,
     asset_server: Res<AssetServer>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let skeleton = SkeletonData::new_from_binary(
         asset_server.load("spineboy/export/spineboy-pro.skel"),

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use bevy::{
-    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
+    asset::{io::Reader, AssetLoader, LoadContext},
     prelude::*,
     reflect::TypePath,
 };
@@ -32,11 +32,11 @@ impl AssetLoader for AtlasLoader {
     type Settings = ();
     type Error = SpineLoaderError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader<'_>,
-        _settings: &'a Self::Settings,
-        load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
@@ -72,11 +72,11 @@ impl AssetLoader for SkeletonJsonLoader {
     type Settings = ();
     type Error = SpineLoaderError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader<'_>,
-        _settings: &'a Self::Settings,
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
@@ -106,11 +106,11 @@ impl AssetLoader for SkeletonBinaryLoader {
     type Settings = ();
     type Error = SpineLoaderError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader<'_>,
-        _settings: &'a Self::Settings,
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;

--- a/src/crossfades.rs
+++ b/src/crossfades.rs
@@ -9,7 +9,6 @@ use rusty_spine::AnimationStateData;
 /// Apply to a [`SpineBundle`](`crate::SpineBundle`) upon creation:
 ///
 /// ```
-
 /// # use bevy::prelude::*;
 /// # use bevy_spine::prelude::*;
 /// # fn doc(mut commands: Commands) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,14 @@ use std::{
 
 use bevy::{
     asset::load_internal_binary_asset,
+    image::{ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor},
     prelude::*,
     render::{
         mesh::{Indices, MeshVertexAttribute},
         render_asset::RenderAssetUsages,
         render_resource::{PrimitiveTopology, VertexFormat},
-        texture::{ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor},
     },
-    sprite::{Material2dPlugin, Mesh2dHandle},
+    sprite::Material2dPlugin,
 };
 use materials::{
     SpineAdditiveMaterial, SpineAdditivePmaMaterial, SpineMaterialInfo, SpineMultiplyMaterial,
@@ -258,36 +258,16 @@ impl core::ops::DerefMut for Spine {
 /// entities representing the bones of a skeleton (see [`SpineBone`]). These bones are not
 /// synchronized (see [`SpineSync`]), and can be disabled entirely using
 /// [`SpineLoader::without_children`].
-#[derive(Component, Debug)]
-pub enum SpineLoader {
-    /// The spine rig is still loading.
-    Loading {
-        /// If true, will spawn child entities for each bone in the skeleton (see [`SpineBone`]).
-        with_children: bool,
-    },
-    /// The spine rig is ready.
-    Ready,
-    /// The spine rig failed to load.
-    Failed,
-}
-
-impl Default for SpineLoader {
-    fn default() -> Self {
-        Self::new()
-    }
+#[derive(Default, Component, Debug)]
+pub struct SpineLoader {
+    pub skeleton: Handle<SkeletonData>,
+    /// If true, will spawn child entities for each bone in the skeleton (see [`SpineBone`]).
+    pub with_children: bool,
 }
 
 impl SpineLoader {
-    pub fn new() -> Self {
-        Self::with_children()
-    }
-
-    pub fn with_children() -> Self {
-        Self::Loading {
-            with_children: true,
-        }
-    }
-
+    // 0.15 TODO
+    /*
     /// Load a [`Spine`] entity without child entities containing [`SpineBone`] components.
     ///
     /// Renderable mesh child entities are still created.
@@ -304,10 +284,19 @@ impl SpineLoader {
     /// # }
     /// ```
     pub fn without_children() -> Self {
-        Self::Loading {
+        Self {
             with_children: false,
+            state: SpineLoadState::Loading,
         }
-    }
+    }*/
+}
+
+#[derive(Component, Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpineLoadState {
+    #[default]
+    Loading,
+    Ready,
+    Failed,
 }
 
 /// Settings for how this Spine updates and renders.
@@ -317,7 +306,7 @@ impl SpineLoader {
 pub struct SpineSettings {
     /// Indicates if default Spine materials should be used (default: `true`).
     ///
-    /// If `false`, a custom [`SpineMaterial`](`materials::SpineMaterial`) should be configured for
+    /// If `false`, a custom [`SpineMaterial2d`](`materials::SpineMaterial2d`) should be configured for
     /// this Spine.
     pub default_materials: bool,
     /// Indicates how the meshes should be drawn.
@@ -331,7 +320,7 @@ pub struct SpineSettings {
 pub enum SpineMeshType {
     /// Render meshes in 2D.
     Mesh2D,
-    /// Render meshes in 3D. Requires a custom [`SpineMaterial`](`materials::SpineMaterial`) since
+    /// Render meshes in 3D. Requires a custom [`SpineMaterial2d`](`materials::SpineMaterial2d`) since
     /// the default materials do not support 3D meshes.
     Mesh3D,
 }
@@ -430,8 +419,8 @@ impl Default for SpineSettings {
 #[derive(Default, Bundle)]
 pub struct SpineBundle {
     pub loader: SpineLoader,
+    pub load_state: SpineLoadState,
     pub settings: SpineSettings,
-    pub skeleton: Handle<SkeletonData>,
     pub crossfades: Crossfades,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
@@ -599,9 +588,9 @@ fn spine_load(
 #[allow(clippy::too_many_arguments)]
 fn spine_spawn(
     mut skeleton_query: Query<(
-        &mut SpineLoader,
+        &SpineLoader,
+        &mut SpineLoadState,
         Entity,
-        &Handle<SkeletonData>,
         Option<&Crossfades>,
     )>,
     mut commands: Commands,
@@ -610,14 +599,16 @@ fn spine_spawn(
     mut skeleton_data_assets: ResMut<Assets<SkeletonData>>,
     spine_event_queue: Res<SpineEventQueue>,
 ) {
-    for (mut spine_loader, spine_entity, data_handle, crossfades) in skeleton_query.iter_mut() {
-        if let SpineLoader::Loading { with_children } = spine_loader.as_ref() {
-            let skeleton_data_asset =
-                if let Some(skeleton_data_asset) = skeleton_data_assets.get_mut(data_handle) {
-                    skeleton_data_asset
-                } else {
-                    continue;
-                };
+    for (spine_loader, mut spine_load_state, spine_entity, crossfades) in skeleton_query.iter_mut()
+    {
+        if matches!(spine_load_state.as_ref(), SpineLoadState::Loading) {
+            let skeleton_data_asset = if let Some(skeleton_data_asset) =
+                skeleton_data_assets.get_mut(&spine_loader.skeleton)
+            {
+                skeleton_data_asset
+            } else {
+                continue;
+            };
             match &skeleton_data_asset.status {
                 SkeletonDataStatus::Loaded(skeleton_data) => {
                     let mut animation_state_data = AnimationStateData::new(skeleton_data.clone());
@@ -738,7 +729,7 @@ fn spine_spawn(
                                             z += 0.001;
                                         }
                                     });
-                                if *with_children {
+                                if spine_loader.with_children {
                                     spawn_bones(
                                         spine_entity,
                                         None,
@@ -751,7 +742,7 @@ fn spine_spawn(
                             })
                             .insert(Spine(controller));
                     }
-                    *spine_loader = SpineLoader::Ready;
+                    *spine_load_state = SpineLoadState::Ready;
                     ready_events.0.push(SpineReadyEvent {
                         entity: spine_entity,
                         bones,
@@ -759,7 +750,7 @@ fn spine_spawn(
                 }
                 SkeletonDataStatus::Loading => {}
                 SkeletonDataStatus::Failed => {
-                    *spine_loader = SpineLoader::Failed;
+                    *spine_load_state = SpineLoadState::Failed;
                 }
             }
         }
@@ -833,7 +824,7 @@ fn spine_update_animation(
     spine_event_queue: Res<SpineEventQueue>,
 ) {
     for (_, mut spine) in spine_query.iter_mut() {
-        spine.update(time.delta_seconds(), Physics::Update);
+        spine.update(time.delta_secs(), Physics::Update);
     }
     {
         let mut events = spine_event_queue.0.lock().unwrap();
@@ -856,8 +847,8 @@ fn spine_update_meshes(
         Entity,
         &mut SpineMesh,
         &mut Transform,
-        Option<&Mesh2dHandle>,
-        Option<&Handle<Mesh>>,
+        Option<&Mesh2d>,
+        Option<&Mesh3d>,
     )>,
     mut commands: Commands,
     meshes_query: Query<(&Parent, &Children), With<SpineMeshes>>,
@@ -908,14 +899,14 @@ fn spine_update_meshes(
                 apply_mesh!(
                     spine_2d_mesh,
                     mesh_type == SpineMeshType::Mesh2D,
-                    Mesh2dHandle(spine_mesh.handle.clone()),
-                    Mesh2dHandle
+                    Mesh2d(spine_mesh.handle.clone()),
+                    Mesh2d
                 );
                 apply_mesh!(
                     spine_3d_mesh,
                     mesh_type == SpineMeshType::Mesh3D,
-                    spine_mesh.handle.clone(),
-                    Handle<Mesh>
+                    Mesh3d(spine_mesh.handle.clone()),
+                    Mesh3d
                 );
                 let Some(mesh) = meshes.get_mut(&spine_mesh.handle) else {
                     continue;

--- a/src/test.rs
+++ b/src/test.rs
@@ -42,11 +42,14 @@ pub fn test_app_with_spineboy() -> App {
                 asset_server.load("spineboy/export/spineboy.atlas"),
             );
             let skeleton_handle = skeletons.add(skeleton);
-            commands.spawn(SpineBundle {
-                skeleton: skeleton_handle.clone(),
+            commands.spawn((SpineBundle {
+                loader: SpineLoader {
+                    skeleton: skeleton_handle.clone(),
+                    ..Default::default()
+                },
                 transform: Transform::from_xyz(0., -200., 0.).with_scale(Vec3::ONE * 0.5),
                 ..Default::default()
-            });
+            },));
         },
     );
     let ready = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
This PR (Continuing work from: #30 ) renames SpineMaterial to SpineMaterial2d and introduces a new SpineMaterial3d that allows the use of StandardMaterial to render Spine animations in 3D.

While using StandardMaterial works for 3D visualization, the result appears quite dark by default. To address this, the example uses the unlit flag. However, this is a temporary workaround, and it may be beneficial for someone to create a shader-based solution to correct the dark appearance in the future.

Feel free to test and share your feedback!

![162352](https://github.com/user-attachments/assets/717d6318-c3a1-4b1a-8475-ad49f24defe0)