### PR TITLE
bring this back from the dead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,19 @@ ui = ["bevy/bevy_ui"]
 
 [dependencies]
 rusty_spine = "0.8"
-bevy = { version = "^0.17.2", default-features = false, features = [
-    "bevy_render",
-    "bevy_asset",
-    "bevy_sprite",
+bevy = { version = "0.17", default-features = false, features = [
+  "bevy_render",
+  "bevy_asset",
+  "bevy_sprite",
 ] }
-glam = { version = "0.30.8", features = ["mint"] }
-thiserror = "1.0.50"
+glam = { version = "0.30", features = ["mint"] }
+thiserror = "2.0.18"
 
 [dev-dependencies]
 lerp = "0.5"
-bevy = { version = "^0.17.2", default-features = true, features = ["bevy_ui_debug"] }
+bevy = { version = "0.17", default-features = true, features = [
+  "bevy_ui_debug",
+] }
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ readme = "readme.md"
 license-file = "LICENSE"
 exclude = ["assets/*"]
 
+[features]
+default = []
+ui = ["bevy/bevy_ui"]
+
 [dependencies]
 rusty_spine = "0.8"
 bevy = { version = "^0.17.2", default-features = false, features = [
@@ -21,8 +25,12 @@ thiserror = "1.0.50"
 
 [dev-dependencies]
 lerp = "0.5"
-bevy = { version = "^0.17.2", default-features = true }
+bevy = { version = "^0.17.2", default-features = true, features = ["bevy_ui_debug"] }
 
 [workspace]
 resolver = "2"
 members = ["ci"]
+
+[[example]]
+name = "ui_spine_showcase"
+required-features = ["ui"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_spine"
-version = "0.10.1"
-edition = "2021"
+version = "0.11.0"
+edition = "2024"
 description = "Spine plugin for Bevy utilizing rusty_spine"
 homepage = "https://github.com/jabuwu/bevy_spine"
 repository = "https://github.com/jabuwu/bevy_spine"
@@ -11,17 +11,17 @@ exclude = ["assets/*"]
 
 [dependencies]
 rusty_spine = "0.8"
-bevy = { version = "^0.15.2", default-features = false, features = [
+bevy = { version = "^0.17.2", default-features = false, features = [
     "bevy_render",
     "bevy_asset",
     "bevy_sprite",
 ] }
-glam = { version = "0.29", features = ["mint"] }
+glam = { version = "0.30.8", features = ["mint"] }
 thiserror = "1.0.50"
 
 [dev-dependencies]
 lerp = "0.5"
-bevy = { version = "0.15", default-features = true }
+bevy = { version = "^0.17.2", default-features = true }
 
 [workspace]
 resolver = "2"

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -4,6 +4,7 @@ use bevy::{
     prelude::*,
     window::{CursorGrabMode, PrimaryWindow},
 };
+use bevy::window::CursorOptions;
 use bevy_spine::{
     materials::{SpineMaterial, SpineMaterialInfo, SpineMaterialPlugin, SpineSettingsQuery},
     prelude::*,
@@ -86,7 +87,7 @@ fn setup(
 }
 
 fn on_spawn(
-    mut spine_ready_event: EventReader<SpineReadyEvent>,
+    mut spine_ready_event: MessageReader<SpineReadyEvent>,
     mut spine_query: Query<&mut Spine>,
 ) {
     for event in spine_ready_event.read() {
@@ -100,25 +101,25 @@ fn on_spawn(
 }
 
 fn controls(
-    mut window_query: Query<&mut Window, With<PrimaryWindow>>,
-    mut mouse_motion_events: EventReader<MouseMotion>,
+    window_query: Single<&mut CursorOptions, With<PrimaryWindow>>,
+    mut mouse_motion_events: MessageReader<MouseMotion>,
     mut orbit_query: Query<(&mut Orbit, &mut Transform)>,
     mouse_buttons: Res<ButtonInput<MouseButton>>,
     keys: Res<ButtonInput<KeyCode>>,
 ) {
-    let mut window = window_query.single_mut();
+    let mut cursor_options = window_query.into_inner();
     if mouse_buttons.just_pressed(MouseButton::Left) {
-        window.cursor_options.grab_mode = CursorGrabMode::Locked;
-        window.cursor_options.visible = false;
+        cursor_options.grab_mode = CursorGrabMode::Locked;
+        cursor_options.visible = false;
     }
     if keys.just_pressed(KeyCode::Escape) {
-        window.cursor_options.grab_mode = CursorGrabMode::None;
-        window.cursor_options.visible = true;
+        cursor_options.grab_mode = CursorGrabMode::None;
+        cursor_options.visible = true;
     }
 
     let mut mouse_movement = Vec2::ZERO;
     for mouse_motion_event in mouse_motion_events.read() {
-        if window.cursor_options.grab_mode == CursorGrabMode::Locked {
+        if cursor_options.grab_mode == CursorGrabMode::Locked {
             mouse_movement += mouse_motion_event.delta;
         }
     }

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -1,14 +1,14 @@
+use bevy::window::CursorOptions;
 use bevy::{
     ecs::system::StaticSystemParam,
     input::mouse::MouseMotion,
     prelude::*,
     window::{CursorGrabMode, PrimaryWindow},
 };
-use bevy::window::CursorOptions;
 use bevy_spine::{
+    SpineMeshType,
     materials::{SpineMaterial, SpineMaterialInfo, SpineMaterialPlugin, SpineSettingsQuery},
     prelude::*,
-    SpineMeshType,
 };
 
 #[derive(Component)]

--- a/examples/crossfades.rs
+++ b/examples/crossfades.rs
@@ -46,7 +46,7 @@ fn setup(
 }
 
 fn on_spawn(
-    mut spine_ready_event: EventReader<SpineReadyEvent>,
+    mut spine_ready_event: MessageReader<SpineReadyEvent>,
     mut spine_query: Query<&mut Spine>,
 ) {
     for event in spine_ready_event.read() {

--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -3,13 +3,14 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::{
-        mesh::MeshVertexBufferLayoutRef,
         render_resource::{
-            AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
+            AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError,
         },
     },
-    sprite::{AlphaMode2d, Material2d, Material2dKey, Material2dPlugin},
 };
+use bevy::mesh::MeshVertexBufferLayoutRef;
+use bevy::shader::ShaderRef;
+use bevy::sprite_render::{AlphaMode2d, Material2d, Material2dKey, Material2dPlugin};
 use bevy_spine::{
     materials::{
         SpineMaterial, SpineMaterialInfo, SpineMaterialPlugin, DARK_COLOR_ATTRIBUTE,
@@ -69,7 +70,7 @@ fn setup(
 }
 
 fn on_spawn(
-    mut spine_ready_event: EventReader<SpineReadyEvent>,
+    mut spine_ready_event: MessageReader<SpineReadyEvent>,
     mut spine_query: Query<&mut Spine>,
 ) {
     for event in spine_ready_event.read() {

--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -1,23 +1,21 @@
+use bevy::mesh::MeshVertexBufferLayoutRef;
+use bevy::shader::ShaderRef;
+use bevy::sprite_render::{AlphaMode2d, Material2d, Material2dKey, Material2dPlugin};
 use bevy::{
     ecs::system::{StaticSystemParam, SystemParam},
     prelude::*,
     reflect::TypePath,
-    render::{
-        render_resource::{
-            AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError,
-        },
+    render::render_resource::{
+        AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError,
     },
 };
-use bevy::mesh::MeshVertexBufferLayoutRef;
-use bevy::shader::ShaderRef;
-use bevy::sprite_render::{AlphaMode2d, Material2d, Material2dKey, Material2dPlugin};
 use bevy_spine::{
-    materials::{
-        SpineMaterial, SpineMaterialInfo, SpineMaterialPlugin, DARK_COLOR_ATTRIBUTE,
-        DARK_COLOR_SHADER_POSITION,
-    },
     SkeletonController, SkeletonData, Spine, SpineBundle, SpineDrawer, SpinePlugin,
     SpineReadyEvent, SpineSet, SpineSettings,
+    materials::{
+        DARK_COLOR_ATTRIBUTE, DARK_COLOR_SHADER_POSITION, SpineMaterial, SpineMaterialInfo,
+        SpineMaterialPlugin,
+    },
 };
 
 fn main() {

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -40,7 +40,7 @@ fn setup(
 }
 
 fn on_spawn(
-    mut spine_ready_event: EventReader<SpineReadyEvent>,
+    mut spine_ready_event: MessageReader<SpineReadyEvent>,
     mut spine_query: Query<&mut Spine>,
 ) {
     for event in spine_ready_event.read() {
@@ -53,7 +53,7 @@ fn on_spawn(
     }
 }
 
-fn on_spine_event(mut spine_events: EventReader<SpineEvent>, mut commands: Commands) {
+fn on_spine_event(mut spine_events: MessageReader<SpineEvent>, mut commands: Commands) {
     for event in spine_events.read() {
         if let SpineEvent::Event { name, .. } = event {
             commands

--- a/examples/immediate_spawn.rs
+++ b/examples/immediate_spawn.rs
@@ -1,6 +1,7 @@
 //! Demonstrates how to spawn a [`SpineBundle`] and use it in one frame.
 
-use bevy::{app::AppExit, core::FrameCount, prelude::*};
+use bevy::diagnostic::FrameCount;
+use bevy::prelude::*;
 use bevy_spine::{
     SkeletonData, Spine, SpineBundle, SpinePlugin, SpineReadyEvent, SpineSet, SpineSystem,
 };
@@ -20,7 +21,7 @@ fn main() {
             (
                 spawn.in_set(ExampleSet::Spawn).after(SpineSystem::Load),
                 on_spawn.in_set(SpineSet::OnReady),
-                apply_deferred
+                ApplyDeferred
                     .after(ExampleSet::Spawn)
                     .before(SpineSystem::Spawn),
             ),
@@ -71,14 +72,14 @@ fn spawn(
 }
 
 fn on_spawn(
-    mut spine_ready_event: EventReader<SpineReadyEvent>,
-    mut app_exit: EventWriter<AppExit>,
+    mut spine_ready_event: MessageReader<SpineReadyEvent>,
+    mut app_exit: MessageWriter<AppExit>,
     spine_query: Query<&Spine>,
     frame_count: Res<FrameCount>,
 ) {
     for event in spine_ready_event.read() {
         assert!(spine_query.contains(event.entity));
         println!("ready on frame: {}", frame_count.0);
-        app_exit.send_default();
+        app_exit.write_default();
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -32,7 +32,7 @@ fn setup(
 }
 
 fn on_spawn(
-    mut spine_ready_event: EventReader<SpineReadyEvent>,
+    mut spine_ready_event: MessageReader<SpineReadyEvent>,
     mut spine_query: Query<&mut Spine>,
 ) {
     for event in spine_ready_event.read() {

--- a/examples/spineboy/bullet.rs
+++ b/examples/spineboy/bullet.rs
@@ -10,7 +10,7 @@ pub struct BulletPlugin;
 
 impl Plugin for BulletPlugin {
     fn build(&self, app: &mut App) {
-        app.add_event::<BulletSpawnEvent>().add_systems(
+        app.add_message::<BulletSpawnEvent>().add_systems(
             Update,
             (
                 bullet_spawn.in_set(BulletSystem::Spawn),
@@ -22,7 +22,7 @@ impl Plugin for BulletPlugin {
     }
 }
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct BulletSpawnEvent {
     pub position: Vec2,
     pub velocity: Vec2,
@@ -33,7 +33,7 @@ pub struct Bullet {
     pub velocity: Vec2,
 }
 
-fn bullet_spawn(mut commands: Commands, mut bullet_spawn_events: EventReader<BulletSpawnEvent>) {
+fn bullet_spawn(mut commands: Commands, mut bullet_spawn_events: MessageReader<BulletSpawnEvent>) {
     for event in bullet_spawn_events.read() {
         commands
             .spawn((

--- a/examples/spineboy/main.rs
+++ b/examples/spineboy/main.rs
@@ -13,7 +13,7 @@ fn main() {
 fn setup(
     mut commands: Commands,
     mut skeletons: ResMut<Assets<SkeletonData>>,
-    mut player_spawn_events: EventWriter<PlayerSpawnEvent>,
+    mut player_spawn_events: MessageWriter<PlayerSpawnEvent>,
     asset_server: Res<AssetServer>,
 ) {
     commands.spawn(Camera2d);
@@ -23,7 +23,7 @@ fn setup(
         asset_server.load("spineboy/export/spineboy-pma.atlas"),
     );
     let skeleton_handle = skeletons.add(skeleton);
-    player_spawn_events.send(PlayerSpawnEvent {
+    player_spawn_events.write(PlayerSpawnEvent {
         skeleton: skeleton_handle,
     });
 }

--- a/examples/ui_spine_showcase.rs
+++ b/examples/ui_spine_showcase.rs
@@ -1,0 +1,288 @@
+use bevy::{prelude::*, ui_render::UiDebugOptions};
+use bevy_spine::{
+    SkeletonController, SkeletonData, Spine, SpinePlugin, SpineUiAnimation, SpineUiBundle,
+    SpineUiFit, SpineUiNode, SpineUiProxy,
+};
+
+fn main() {
+    App::new()
+        .insert_resource(ShowcaseState::default())
+        .add_plugins((DefaultPlugins, SpinePlugin))
+        .add_systems(Startup, (setup, enable_ui_debug_overlay))
+        .add_systems(
+            Update,
+            (
+                showcase_input,
+                apply_showcase_state,
+                toggle_ui_debug_overlay,
+            ),
+        )
+        .run();
+}
+
+#[derive(Resource)]
+struct ShowcaseState {
+    fit: SpineUiFit,
+    auto_size_enabled: bool,
+    tint_index: usize,
+    animation_index: usize,
+}
+
+impl Default for ShowcaseState {
+    fn default() -> Self {
+        Self {
+            fit: SpineUiFit::Contain,
+            auto_size_enabled: true,
+            tint_index: 0,
+            animation_index: 0,
+        }
+    }
+}
+
+#[derive(Component)]
+struct InteractiveSpine;
+
+#[derive(Component)]
+struct AutoSizeSpine(Vec2);
+
+fn setup(
+    asset_server: Res<AssetServer>,
+    mut commands: Commands,
+    mut skeletons: ResMut<Assets<SkeletonData>>,
+) {
+    commands.spawn(Camera2d);
+
+    let skeleton = SkeletonData::new_from_json(
+        asset_server.load("spineboy/export/spineboy-pro.json"),
+        asset_server.load("spineboy/export/spineboy-pma.atlas"),
+    );
+    let skeleton_handle = skeletons.add(skeleton);
+
+    commands
+        .spawn((
+            Node {
+                width: percent(100),
+                height: percent(100),
+                flex_direction: FlexDirection::Column,
+                row_gap: px(10),
+                padding: UiRect::all(px(12)),
+                ..default()
+            },
+            BackgroundColor(Color::srgb(0.06, 0.06, 0.08)),
+        ))
+        .with_children(|root| {
+            root.spawn((
+                Text::new(
+                    "Spine UI Showcase\n[1-4] fit: contain/cover/fill/none  [A] auto-size  [T] tint  [Space] animation  [F1] UI borders",
+                ),
+                TextColor(Color::srgb(0.9, 0.92, 0.97)),
+            ));
+
+            root.spawn(Node {
+                width: percent(100),
+                height: percent(100),
+                display: Display::Grid,
+                grid_template_columns: vec![GridTrack::fr(1.0), GridTrack::fr(1.0)],
+                grid_template_rows: vec![GridTrack::fr(1.0), GridTrack::fr(1.0)],
+                row_gap: px(8),
+                column_gap: px(8),
+                ..default()
+            })
+            .with_children(|grid| {
+                spawn_panel(
+                    grid,
+                    "Interactive (explicit size)",
+                    skeleton_handle.clone(),
+                    Node {
+                        width: percent(100),
+                        height: percent(100),
+                        min_height: px(220),
+                        ..default()
+                    },
+                    SpineUiNode {
+                        animation: Some(SpineUiAnimation::looping("walk")),
+                        auto_size: None,
+                        ..default()
+                    },
+                    Some(InteractiveSpine),
+                    None,
+                );
+
+                spawn_panel(
+                    grid,
+                    "Auto-size node",
+                    skeleton_handle.clone(),
+                    Node::default(),
+                    SpineUiNode {
+                        animation: Some(SpineUiAnimation::looping("portal")),
+                        auto_size: Some(Vec2::new(260.0, 380.0)),
+                        ..default()
+                    },
+                    Some(InteractiveSpine),
+                    Some(AutoSizeSpine(Vec2::new(260.0, 380.0))),
+                );
+
+                spawn_panel(
+                    grid,
+                    "Tint sample",
+                    skeleton_handle.clone(),
+                    Node {
+                        width: percent(100),
+                        height: percent(100),
+                        min_height: px(220),
+                        ..default()
+                    },
+                    SpineUiNode {
+                        animation: Some(SpineUiAnimation::looping("walk")),
+                        tint: Color::srgb(1.0, 0.85, 0.75),
+                        ..default()
+                    },
+                    Some(InteractiveSpine),
+                    None,
+                );
+
+                grid.spawn((
+                    Node {
+                        width: percent(100),
+                        height: percent(100),
+                        min_height: px(220),
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        ..default()
+                    },
+                    BackgroundColor(Color::srgb(0.13, 0.14, 0.17)),
+                    BorderColor::all(Color::srgb(0.24, 0.26, 0.33)),
+                    BorderRadius::all(px(8)),
+                ))
+                .with_children(|panel| {
+                    panel.spawn((
+                        Text::new(
+                            "Uses ViewportNode internally\nworld Spine renderer + UI layout",
+                        ),
+                        TextColor(Color::srgb(0.85, 0.88, 0.94)),
+                    ));
+                });
+            });
+        });
+}
+
+fn spawn_panel(
+    parent: &mut ChildSpawnerCommands,
+    title: &str,
+    skeleton: Handle<SkeletonData>,
+    viewport_node: Node,
+    spine_ui: SpineUiNode,
+    interactive: Option<InteractiveSpine>,
+    auto_size: Option<AutoSizeSpine>,
+) {
+    parent
+        .spawn((
+            Node {
+                width: percent(100),
+                height: percent(100),
+                min_height: px(220),
+                flex_direction: FlexDirection::Column,
+                row_gap: px(6),
+                padding: UiRect::all(px(8)),
+                ..default()
+            },
+            BackgroundColor(Color::srgb(0.11, 0.12, 0.15)),
+            BorderColor::all(Color::srgb(0.24, 0.26, 0.33)),
+            BorderRadius::all(px(8)),
+        ))
+        .with_children(|panel| {
+            panel.spawn((Text::new(title), TextColor(Color::srgb(0.9, 0.9, 0.95))));
+            let mut entity = panel.spawn(SpineUiBundle {
+                node: viewport_node,
+                spine_ui,
+                skeleton: skeleton.into(),
+                ..default()
+            });
+            if let Some(marker) = interactive {
+                entity.insert(marker);
+            }
+            if let Some(marker) = auto_size {
+                entity.insert(marker);
+            }
+        });
+}
+
+fn showcase_input(mut state: ResMut<ShowcaseState>, input: Res<ButtonInput<KeyCode>>) {
+    if input.just_pressed(KeyCode::Digit1) {
+        state.fit = SpineUiFit::Contain;
+    }
+    if input.just_pressed(KeyCode::Digit2) {
+        state.fit = SpineUiFit::Cover;
+    }
+    if input.just_pressed(KeyCode::Digit3) {
+        state.fit = SpineUiFit::Fill;
+    }
+    if input.just_pressed(KeyCode::Digit4) {
+        state.fit = SpineUiFit::None;
+    }
+
+    if input.just_pressed(KeyCode::KeyA) {
+        state.auto_size_enabled = !state.auto_size_enabled;
+    }
+    if input.just_pressed(KeyCode::KeyT) {
+        state.tint_index = (state.tint_index + 1) % 4;
+    }
+    if input.just_pressed(KeyCode::Space) {
+        state.animation_index = (state.animation_index + 1) % 3;
+    }
+}
+
+fn apply_showcase_state(
+    state: Res<ShowcaseState>,
+    mut ui_nodes: Query<
+        (&mut SpineUiNode, Option<&AutoSizeSpine>, &SpineUiProxy),
+        With<InteractiveSpine>,
+    >,
+    mut spine_query: Query<&mut Spine>,
+) {
+    if !state.is_changed() {
+        return;
+    }
+
+    let tint = match state.tint_index {
+        0 => Color::WHITE,
+        1 => Color::srgb(1.0, 0.82, 0.78),
+        2 => Color::srgb(0.78, 0.9, 1.0),
+        _ => Color::srgb(0.86, 1.0, 0.8),
+    };
+
+    let animation = match state.animation_index {
+        0 => "walk",
+        1 => "run",
+        _ => "portal",
+    };
+
+    for (mut spine_ui, auto_size, proxy) in &mut ui_nodes {
+        spine_ui.fit = state.fit;
+        spine_ui.tint = tint;
+        if let Some(auto_size) = auto_size {
+            spine_ui.auto_size = state.auto_size_enabled.then_some(auto_size.0);
+        }
+
+        if let Ok(mut spine) = spine_query.get_mut(proxy.proxy_entity) {
+            let Spine(SkeletonController {
+                animation_state, ..
+            }) = spine.as_mut();
+            let _ = animation_state.set_animation_by_name(0, animation, true);
+        }
+    }
+}
+
+fn enable_ui_debug_overlay(mut debug_options: ResMut<UiDebugOptions>) {
+    debug_options.enabled = true;
+    debug_options.show_clipped = true;
+}
+
+fn toggle_ui_debug_overlay(
+    input: Res<ButtonInput<KeyCode>>,
+    mut debug_options: ResMut<UiDebugOptions>,
+) {
+    if input.just_pressed(KeyCode::F1) {
+        debug_options.toggle();
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,8 @@ A Bevy Plugin for [Spine](http://esotericsoftware.com/), utilizing [rusty_spine]
 
 ```
 [dependencies]
-bevy = "0.14"
-bevy_spine = "0.10"
+bevy = "0.17"
+bevy_spine = "0.11"
 ```
 
 [See online demos!](https://jabuwu.github.io/bevy_spine_demos/) ([source repo](https://github.com/jabuwu/bevy_spine_demos))
@@ -13,7 +13,8 @@ bevy_spine = "0.10"
 ## Versions
 
 | bevy_spine | rusty_spine | bevy | spine |
-| ---------- | ----------- | ---- | ----- |
+|------------| ----------- |------| ----- |
+| 0.11       | 0.8         | 0.17 | 4.2   |
 | 0.10       | 0.8         | 0.14 | 4.2   |
 | 0.9        | 0.8         | 0.13 | 4.2   |
 | 0.8        | 0.7         | 0.13 | 4.1   |

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,21 @@ bevy_spine = "0.11"
 
 [See online demos!](https://jabuwu.github.io/bevy_spine_demos/) ([source repo](https://github.com/jabuwu/bevy_spine_demos))
 
+## UI Rendering
+
+`bevy_spine` now includes optional UI node rendering through the `ui` feature.
+
+```toml
+[dependencies]
+bevy_spine = { version = "0.11", features = ["ui"] }
+```
+
+`SpineUiBundle` renders a Spine instance into a `ViewportNode`, so it can live inside Bevy UI layout.
+
+Example:
+
+- `cargo run --example ui_spine_showcase --features ui`
+
 ## Versions
 
 | bevy_spine | rusty_spine | bevy | spine |

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -3,7 +3,6 @@ use std::{path::Path, sync::Arc};
 use bevy::{
     asset::{AssetLoader, LoadContext, io::Reader},
     prelude::*,
-    reflect::TypePath,
 };
 use rusty_spine::SpineError;
 use thiserror::Error;
@@ -19,7 +18,8 @@ pub enum SpineLoaderError {
 /// Bevy asset for [`rusty_spine::Atlas`], loaded from `.atlas` files.
 ///
 /// For loading a complete skeleton, see [`SkeletonData`].
-#[derive(Asset, Debug, TypePath)]
+#[derive(Asset, Debug, Clone, Reflect)]
+#[reflect(opaque)]
 pub struct Atlas {
     pub atlas: Arc<rusty_spine::Atlas>,
 }
@@ -59,7 +59,7 @@ impl AssetLoader for AtlasLoader {
 /// Bevy asset for [`rusty_spine::SkeletonJson`], loaded from `.json` files.
 ///
 /// For loading a complete skeleton, see [`SkeletonData`].
-#[derive(Asset, Debug, TypePath)]
+#[derive(Asset, Debug, Clone, Reflect)]
 pub struct SkeletonJson {
     pub json: Vec<u8>,
 }
@@ -93,7 +93,7 @@ impl AssetLoader for SkeletonJsonLoader {
 /// Bevy asset for [`rusty_spine::SkeletonBinary`], loaded from `.skel` files.
 ///
 /// For loading a complete skeleton, see [`SkeletonData`].
-#[derive(Asset, Debug, TypePath)]
+#[derive(Asset, Debug, Clone, Reflect)]
 pub struct SkeletonBinary {
     pub binary: Vec<u8>,
 }
@@ -128,7 +128,7 @@ impl AssetLoader for SkeletonBinaryLoader {
 /// skeleton (either [`SkeletonJson`] or [`SkeletonBinary`]).
 ///
 /// See [`SkeletonData::new_from_json`] or [`SkeletonData::new_from_binary`].
-#[derive(Asset, Debug, TypePath)]
+#[derive(Asset, Debug, Clone, Reflect)]
 pub struct SkeletonData {
     pub atlas_handle: Handle<Atlas>,
     pub kind: SkeletonDataKind,
@@ -136,13 +136,14 @@ pub struct SkeletonData {
     pub premultiplied_alpha: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Reflect)]
 pub enum SkeletonDataKind {
     BinaryFile(Handle<SkeletonBinary>),
     JsonFile(Handle<SkeletonJson>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Reflect)]
+#[reflect(opaque)]
 pub enum SkeletonDataStatus {
     Loaded(Arc<rusty_spine::SkeletonData>),
     Loading,

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use bevy::{
-    asset::{io::Reader, AssetLoader, LoadContext},
+    asset::{AssetLoader, LoadContext, io::Reader},
     prelude::*,
     reflect::TypePath,
 };

--- a/src/crossfades.rs
+++ b/src/crossfades.rs
@@ -28,7 +28,8 @@ use rusty_spine::AnimationStateData;
 /// # }
 /// ```
 
-#[derive(Component, Default, Debug, Clone)]
+#[derive(Component, Default, Debug, Clone, Reflect)]
+#[reflect(Component, Default, Debug, Clone)]
 pub struct Crossfades {
     mix_durations: HashMap<(String, String), f32>,
 }

--- a/src/entity_sync.rs
+++ b/src/entity_sync.rs
@@ -221,7 +221,8 @@ pub fn spine_sync_entities_applied<S: SpineSynchronizer>(
 ///
 /// If multiple synchronization steps are needed, additional sync components can be created (see
 /// [`SpineSynchronizerPlugin`]).
-#[derive(Component, Debug, Hash, Clone, Copy, PartialEq, Eq)]
+#[derive(Component, Debug, Hash, Clone, Copy, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Hash, PartialEq, Clone)]
 pub struct SpineSync;
 
 /// The default [`SpineSynchronizerSystem`], see that struct for more docs.

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,7 +1,7 @@
 use crate::SkeletonData;
 use bevy::prelude::*;
 
-#[derive(Default, Component)]
+#[derive(Default, Component, Clone)]
 pub struct SkeletonDataHandle(pub Handle<SkeletonData>);
 
 impl From<Handle<SkeletonData>> for SkeletonDataHandle {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,7 +1,8 @@
 use crate::SkeletonData;
 use bevy::prelude::*;
 
-#[derive(Default, Component, Clone)]
+#[derive(Default, Component, Clone, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct SkeletonDataHandle(pub Handle<SkeletonData>);
 
 impl From<Handle<SkeletonData>> for SkeletonDataHandle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,17 +27,17 @@ use materials::{
     SpineScreenPmaMaterial,
 };
 use rusty_spine::{
-    atlas::{AtlasFilter, AtlasWrap}, controller::{SkeletonCombinedRenderable, SkeletonRenderable}, AnimationEvent,
-    Physics,
-    Skeleton,
+    AnimationEvent, Physics, Skeleton,
+    atlas::{AtlasFilter, AtlasWrap},
+    controller::{SkeletonCombinedRenderable, SkeletonRenderable},
 };
 use textures::SpineTextureConfig;
 
 use crate::{
     assets::{AtlasLoader, SkeletonJsonLoader},
-    materials::{SpineMaterialPlugin, DARK_COLOR_ATTRIBUTE, SHADER_HANDLE},
+    materials::{DARK_COLOR_ATTRIBUTE, SHADER_HANDLE, SpineMaterialPlugin},
     rusty_spine::{
-        controller::SkeletonControllerSettings, draw::CullDirection, AnimationStateData, BoneHandle,
+        AnimationStateData, BoneHandle, controller::SkeletonControllerSettings, draw::CullDirection,
     },
     textures::{SpineTexture, SpineTextureCreateEvent, SpineTextureDisposeEvent, SpineTextures},
 };
@@ -47,6 +47,8 @@ pub use crate::{assets::*, crossfades::Crossfades, entity_sync::*, handle::*, ru
 /// See [`rusty_spine`] docs for more info.
 pub use crate::rusty_spine::controller::SkeletonController;
 
+#[cfg(feature = "ui")]
+pub use crate::ui::*;
 
 pub use rusty_spine;
 
@@ -170,6 +172,9 @@ impl Plugin for SpinePlugin {
             PostUpdate,
             adjust_spine_textures.in_set(SpineSystem::AdjustSpineTextures),
         );
+
+        #[cfg(feature = "ui")]
+        app.add_plugins(ui::SpineUiPlugin);
 
         load_internal_binary_asset!(
             app,
@@ -1144,6 +1149,8 @@ mod assets;
 mod crossfades;
 mod entity_sync;
 mod handle;
+#[cfg(feature = "ui")]
+mod ui;
 
 pub mod materials;
 pub mod textures;
@@ -1155,6 +1162,10 @@ pub mod prelude {
         SpineBundle, SpineEvent, SpineLoader, SpineMesh, SpineMeshState, SpinePlugin,
         SpineReadyEvent, SpineSet, SpineSettings, SpineSync, SpineSyncSet, SpineSyncSystem,
         SpineSystem,
+    };
+    #[cfg(feature = "ui")]
+    pub use crate::{
+        SpineUiBundle, SpineUiDebugState, SpineUiFit, SpineUiNode, SpineUiProxy, SpineUiReadyEvent,
     };
     pub use rusty_spine::{BoneHandle, SlotHandle};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1165,7 +1165,7 @@ pub mod prelude {
     };
     #[cfg(feature = "ui")]
     pub use crate::{
-        SpineUiBundle, SpineUiDebugState, SpineUiFit, SpineUiNode, SpineUiProxy, SpineUiReadyEvent,
+        SpineUiBundle, SpineUiFit, SpineUiNode, SpineUiProxy, SpineUiReadyEvent,
     };
     pub use rusty_spine::{BoneHandle, SlotHandle};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,18 @@ impl Plugin for SpinePlugin {
             SpineMaterialPlugin::<SpineScreenPmaMaterial>::default(),
         ))
         .add_plugins(SpineSyncPlugin::first())
+        .register_type::<Crossfades>()
+        .register_type::<SkeletonDataHandle>()
+        .register_type::<SpineSync>()
+        .register_type::<Spine>()
+        .register_type::<SpineBone>()
+        .register_type::<SpineMeshes>()
+        .register_type::<SpineMesh>()
+        .register_type::<SpineMeshState>()
+        .register_type::<SpineLoader>()
+        .register_type::<SpineSettings>()
+        .register_type::<SpineMeshType>()
+        .register_type::<SpineDrawer>()
         .init_resource::<SpineEventQueue>()
         .insert_resource(SpineTextures::init())
         .insert_resource(SpineReadyEvents::default())
@@ -137,6 +149,10 @@ impl Plugin for SpinePlugin {
         .init_asset::<SkeletonJson>()
         .init_asset::<SkeletonBinary>()
         .init_asset::<SkeletonData>()
+        .register_asset_reflect::<Atlas>()
+        .register_asset_reflect::<SkeletonJson>()
+        .register_asset_reflect::<SkeletonBinary>()
+        .register_asset_reflect::<SkeletonData>()
         .init_asset_loader::<AtlasLoader>()
         .init_asset_loader::<SkeletonJsonLoader>()
         .init_asset_loader::<SkeletonBinaryLoader>()
@@ -196,8 +212,9 @@ struct SpineEventQueue(Arc<Mutex<VecDeque<SpineEvent>>>);
 /// This component does not exist on [`SpineBundle`] initially, since Spine assets may not yet be
 /// loaded when an entity is spawned. Querying for this component type guarantees that all entities
 /// containing it have a Spine rig that is ready to use.
-#[derive(Component, Debug)]
-pub struct Spine(pub SkeletonController);
+#[derive(Component, Debug, Reflect)]
+#[reflect(Component, Debug, from_reflect = false)]
+pub struct Spine(#[reflect(ignore)] pub SkeletonController);
 
 /// When loaded, a [`Spine`] entity has children entities attached to it, each containing this
 /// component.
@@ -206,11 +223,14 @@ pub struct Spine(pub SkeletonController);
 ///
 /// The bones are not automatically synchronized, but can be synchronized easily by adding a
 /// [`SpineSync`] component.
-#[derive(Component, Debug)]
+#[derive(Component, Debug, Reflect)]
+#[reflect(Component, Debug, from_reflect = false)]
 pub struct SpineBone {
     pub spine_entity: Entity,
+    #[reflect(ignore)]
     pub handle: BoneHandle,
     pub name: String,
+    #[reflect(ignore)]
     pub parent: Option<SpineBoneParent>,
 }
 
@@ -220,7 +240,8 @@ pub struct SpineBoneParent {
     pub handle: BoneHandle,
 }
 
-#[derive(Component, Clone)]
+#[derive(Component, Clone, Reflect)]
+#[reflect(Component, Clone)]
 pub struct SpineMeshes;
 
 /// Marker component for child entities containing [`Mesh`] components for Spine rendering.
@@ -228,7 +249,9 @@ pub struct SpineMeshes;
 /// By default, the meshes may contain several meshes all combined into one to reduce draw calls
 /// and improve performance. To interact with individual Spine meshes, see
 /// [`SpineSettings::drawer`].
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(opaque)]
+#[reflect(Component, Debug, Clone)]
 pub struct SpineMesh {
     pub spine_entity: Entity,
     pub handle: Handle<Mesh>,
@@ -236,7 +259,9 @@ pub struct SpineMesh {
 }
 
 /// The state of this [`SpineMesh`].
-#[derive(Default, Component, Debug, Clone)]
+#[derive(Default, Component, Debug, Clone, Reflect)]
+#[reflect(opaque)]
+#[reflect(Component, Default, Debug, Clone)]
 pub enum SpineMeshState {
     /// This Spine mesh contains no mesh data and should not render.
     #[default]
@@ -266,7 +291,8 @@ impl core::ops::DerefMut for Spine {
 /// entities representing the bones of a skeleton (see [`SpineBone`]). These bones are not
 /// synchronized (see [`SpineSync`]), and can be disabled entirely using
 /// [`SpineLoader::without_children`].
-#[derive(Component, Debug)]
+#[derive(Component, Debug, Reflect)]
+#[reflect(Component, Debug)]
 pub enum SpineLoader {
     /// The spine rig is still loading.
     Loading {
@@ -321,7 +347,8 @@ impl SpineLoader {
 /// Settings for how this Spine updates and renders.
 ///
 /// Typically set in [`SpineBundle`] when spawning an entity.
-#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, PartialEq, Clone)]
 pub struct SpineSettings {
     /// Indicates if default Spine materials should be used (default: `true`).
     ///
@@ -335,7 +362,8 @@ pub struct SpineSettings {
 }
 
 /// Mesh types to use in [`SpineSettings`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+#[reflect(Debug, PartialEq, Clone)]
 pub enum SpineMeshType {
     /// Render meshes in 2D.
     Mesh2D,
@@ -345,7 +373,8 @@ pub enum SpineMeshType {
 }
 
 /// Drawer methods to use in [`SpineSettings`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+#[reflect(Debug, PartialEq, Clone)]
 pub enum SpineDrawer {
     /// Draw each slot as a separate mesh, each represented by one [`SpineMesh`].
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,16 +8,18 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use bevy::asset::RenderAssetUsages;
+use bevy::mesh::{Indices, MeshVertexAttribute};
+use bevy::sprite_render::Material2dPlugin;
 use bevy::{
     asset::load_internal_binary_asset,
     image::{ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor},
     prelude::*,
     render::{
-        mesh::{Indices, MeshVertexAttribute},
-        render_asset::RenderAssetUsages,
-        render_resource::{PrimitiveTopology, VertexFormat},
+        render::render_resource::{PrimitiveTopology, VertexFormat},
     },
     sprite::Material2dPlugin,
+    render::render_resource::{PrimitiveTopology, VertexFormat},
 };
 use materials::{
     SpineAdditiveMaterial, SpineAdditivePmaMaterial, SpineMaterialInfo, SpineMultiplyMaterial,
@@ -25,9 +27,9 @@ use materials::{
     SpineScreenPmaMaterial,
 };
 use rusty_spine::{
-    atlas::{AtlasFilter, AtlasWrap},
-    controller::{SkeletonCombinedRenderable, SkeletonRenderable},
-    AnimationEvent, Physics, Skeleton,
+    atlas::{AtlasFilter, AtlasWrap}, controller::{SkeletonCombinedRenderable, SkeletonRenderable}, AnimationEvent,
+    Physics,
+    Skeleton,
 };
 use textures::SpineTextureConfig;
 
@@ -44,6 +46,7 @@ pub use crate::{assets::*, crossfades::Crossfades, entity_sync::*, handle::*, ru
 
 /// See [`rusty_spine`] docs for more info.
 pub use crate::rusty_spine::controller::SkeletonController;
+
 
 pub use rusty_spine;
 
@@ -126,8 +129,8 @@ impl Plugin for SpinePlugin {
         .init_resource::<SpineEventQueue>()
         .insert_resource(SpineTextures::init())
         .insert_resource(SpineReadyEvents::default())
-        .add_event::<SpineTextureCreateEvent>()
-        .add_event::<SpineTextureDisposeEvent>()
+        .add_message::<SpineTextureCreateEvent>()
+        .add_message::<SpineTextureDisposeEvent>()
         .init_asset::<Atlas>()
         .init_asset::<SkeletonJson>()
         .init_asset::<SkeletonBinary>()
@@ -135,8 +138,8 @@ impl Plugin for SpinePlugin {
         .init_asset_loader::<AtlasLoader>()
         .init_asset_loader::<SkeletonJsonLoader>()
         .init_asset_loader::<SkeletonBinaryLoader>()
-        .add_event::<SpineReadyEvent>()
-        .add_event::<SpineEvent>()
+        .add_message::<SpineReadyEvent>()
+        .add_message::<SpineEvent>()
         .add_systems(
             Update,
             (
@@ -157,7 +160,7 @@ impl Plugin for SpinePlugin {
                     .in_set(SpineSet::OnUpdateMesh)
                     .after(SpineSystem::UpdateAnimation)
                     .after(SpineSet::OnEvent),
-                apply_deferred
+                ApplyDeferred
                     .in_set(SpineSystem::SpawnFlush)
                     .after(SpineSystem::Spawn)
                     .before(SpineSystem::Ready),
@@ -440,12 +443,12 @@ pub struct SpineBundle {
     pub view_visibility: ViewVisibility,
 }
 
-/// An [`Event`] which is sent once a [`SpineLoader`] has fully loaded a skeleton and attached the
+/// A [`Message`] which is sent once a [`SpineLoader`] has fully loaded a skeleton and attached the
 /// [`Spine`] component.
 ///
 /// For convenience, systems receiving this event can be added to the [`SpineSet::OnReady`] set to
 /// receive this after events are sent, but before the first [`SkeletonController`] update.
-#[derive(Debug, Clone, Event)]
+#[derive(Debug, Clone, Message)]
 pub struct SpineReadyEvent {
     /// The entity containing the [`Spine`] component.
     pub entity: Entity,
@@ -474,7 +477,7 @@ pub struct SpineReadyEvent {
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, Event)]
+#[derive(Debug, Clone, Message)]
 pub enum SpineEvent {
     Start {
         entity: Entity,
@@ -514,9 +517,9 @@ struct SpineReadyEvents(Vec<SpineReadyEvent>);
 #[allow(clippy::too_many_arguments)]
 fn spine_load(
     mut skeleton_data_assets: ResMut<Assets<SkeletonData>>,
-    mut texture_create_events: EventWriter<SpineTextureCreateEvent>,
-    mut texture_dispose_events: EventWriter<SpineTextureDisposeEvent>,
-    atlases: Res<Assets<Atlas>>,
+    mut texture_create_events: MessageWriter<SpineTextureCreateEvent>,
+    mut texture_dispose_events: MessageWriter<SpineTextureDisposeEvent>,
+    mut atlases: ResMut<Assets<Atlas>>,
     jsons: Res<Assets<SkeletonJson>>,
     binaries: Res<Assets<SkeletonBinary>>,
     spine_textures: Res<SpineTextures>,
@@ -590,7 +593,7 @@ fn spine_load(
 
     spine_textures.update(
         asset_server.as_ref(),
-        atlases.as_ref(),
+        &mut atlases,
         &mut texture_create_events,
         &mut texture_dispose_events,
     );
@@ -696,7 +699,7 @@ fn spine_spawn(
                         });
                     controller.skeleton.set_to_setup_pose();
                     let mut bones = HashMap::new();
-                    if let Some(mut entity_commands) = commands.get_entity(spine_entity) {
+                    if let Ok(mut entity_commands) = commands.get_entity(spine_entity) {
                         entity_commands
                             .with_children(|parent| {
                                 // TODO: currently, a mesh is created for each slot, however when we use the
@@ -769,7 +772,7 @@ fn spine_spawn(
 fn spawn_bones(
     spine_entity: Entity,
     bone_parent: Option<SpineBoneParent>,
-    parent: &mut ChildBuilder,
+    spawner: &mut ChildSpawnerCommands<'_>,
     skeleton: &Skeleton,
     bone: BoneHandle,
     bones: &mut HashMap<String, Entity>,
@@ -782,7 +785,7 @@ fn spawn_bones(
         transform.rotation = Quat::from_axis_angle(Vec3::Z, bone.applied_rotation().to_radians());
         transform.scale.x = bone.applied_scale_x();
         transform.scale.y = bone.applied_scale_y();
-        let bone_entity = parent
+        let bone_entity = spawner
             .spawn((
                 Name::new(format!("spine_bone ({})", bone.data().name())),
                 transform,
@@ -802,7 +805,7 @@ fn spawn_bones(
                     spawn_bones(
                         spine_entity,
                         Some(SpineBoneParent {
-                            entity: parent.parent_entity(),
+                            entity: parent.target_entity(),
                             handle: bone.handle(),
                         }),
                         parent,
@@ -819,16 +822,16 @@ fn spawn_bones(
 
 fn spine_ready(
     mut ready_events: ResMut<SpineReadyEvents>,
-    mut ready_writer: EventWriter<SpineReadyEvent>,
+    mut ready_writer: MessageWriter<SpineReadyEvent>,
 ) {
     for event in take(&mut ready_events.0).into_iter() {
-        ready_writer.send(event);
+        ready_writer.write(event);
     }
 }
 
 fn spine_update_animation(
     mut spine_query: Query<(Entity, &mut Spine)>,
-    mut spine_events: EventWriter<SpineEvent>,
+    mut spine_events: MessageWriter<SpineEvent>,
     time: Res<Time>,
     spine_event_queue: Res<SpineEventQueue>,
 ) {
@@ -838,7 +841,7 @@ fn spine_update_animation(
     {
         let mut events = spine_event_queue.0.lock().unwrap();
         while let Some(event) = events.pop_front() {
-            spine_events.send(event);
+            spine_events.write(event);
         }
     }
 }
@@ -860,11 +863,11 @@ fn spine_update_meshes(
         Option<&Mesh3d>,
     )>,
     mut commands: Commands,
-    meshes_query: Query<(&Parent, &Children), With<SpineMeshes>>,
+    meshes_query: Query<(&ChildOf, &Children), With<SpineMeshes>>,
     asset_server: Res<AssetServer>,
 ) {
     for (meshes_parent, meshes_children) in meshes_query.iter() {
-        let Ok((mut spine, spine_mesh_type)) = spine_query.get_mut(meshes_parent.get()) else {
+        let Ok((mut spine, spine_mesh_type)) = spine_query.get_mut(meshes_parent.parent()) else {
             continue;
         };
         let SpineSettings {
@@ -886,19 +889,19 @@ fn spine_update_meshes(
                 mut spine_mesh_transform,
                 spine_2d_mesh,
                 spine_3d_mesh,
-            )) = mesh_query.get_mut(*child)
+            )) = mesh_query.get_mut(child)
             {
                 macro_rules! apply_mesh {
                     ($mesh:ident, $condition:expr, $attach:expr, $deattach:ty) => {
                         if $condition {
                             if !$mesh.is_some() {
-                                if let Some(mut entity) = commands.get_entity(spine_mesh_entity) {
+                                if let Ok(mut entity) = commands.get_entity(spine_mesh_entity) {
                                     entity.insert($attach);
                                 }
                             }
                         } else {
                             if $mesh.is_some() {
-                                if let Some(mut entity) = commands.get_entity(spine_mesh_entity) {
+                                if let Ok(mut entity) = commands.get_entity(spine_mesh_entity) {
                                     entity.remove::<$deattach>();
                                 }
                             }
@@ -1056,7 +1059,7 @@ struct FixSpineTextures {
 /// Adjusts Spine textures to render properly.
 fn adjust_spine_textures(
     mut local: Local<FixSpineTextures>,
-    mut spine_texture_create_events: EventReader<SpineTextureCreateEvent>,
+    mut spine_texture_create_events: MessageReader<SpineTextureCreateEvent>,
     mut images: ResMut<Assets<Image>>,
 ) {
     for spine_texture_create_event in spine_texture_create_events.read() {
@@ -1099,32 +1102,34 @@ fn adjust_spine_textures(
             // The RGB components exported from Spine were premultiplied in nonlinear space, but need to be
             // multiplied in linear space to render properly in Bevy.
             if handle_config.premultiplied_alpha {
-                for i in 0..(image.data.len() / 4) {
-                    let mut rgba = Srgba::rgba_u8(
-                        image.data[i * 4],
-                        image.data[i * 4 + 1],
-                        image.data[i * 4 + 2],
-                        image.data[i * 4 + 3],
-                    );
-                    if rgba.alpha != 0. {
-                        rgba = Srgba::new(
-                            rgba.red / rgba.alpha,
-                            rgba.green / rgba.alpha,
-                            rgba.blue / rgba.alpha,
-                            rgba.alpha,
+                if let Some(data) = &mut image.data {
+                    for i in 0..(data.len() / 4) {
+                        let mut rgba = Srgba::rgba_u8(
+                            data[i * 4],
+                            data[i * 4 + 1],
+                            data[i * 4 + 2],
+                            data[i * 4 + 3],
                         );
-                    } else {
-                        rgba = Srgba::new(0., 0., 0., 0.);
+                        if rgba.alpha != 0. {
+                            rgba = Srgba::new(
+                                rgba.red / rgba.alpha,
+                                rgba.green / rgba.alpha,
+                                rgba.blue / rgba.alpha,
+                                rgba.alpha,
+                            );
+                        } else {
+                            rgba = Srgba::new(0., 0., 0., 0.);
+                        }
+                        let mut linear_rgba = LinearRgba::from(rgba);
+                        linear_rgba.red *= linear_rgba.alpha;
+                        linear_rgba.green *= linear_rgba.alpha;
+                        linear_rgba.blue *= linear_rgba.alpha;
+                        rgba = Srgba::from(linear_rgba);
+                        data[i * 4] = (rgba.red * 255.) as u8;
+                        data[i * 4 + 1] = (rgba.green * 255.) as u8;
+                        data[i * 4 + 2] = (rgba.blue * 255.) as u8;
+                        data[i * 4 + 3] = (rgba.alpha * 255.) as u8;
                     }
-                    let mut linear_rgba = LinearRgba::from(rgba);
-                    linear_rgba.red *= linear_rgba.alpha;
-                    linear_rgba.green *= linear_rgba.alpha;
-                    linear_rgba.blue *= linear_rgba.alpha;
-                    rgba = Srgba::from(linear_rgba);
-                    image.data[i * 4] = (rgba.red * 255.) as u8;
-                    image.data[i * 4 + 1] = (rgba.green * 255.) as u8;
-                    image.data[i * 4 + 2] = (rgba.blue * 255.) as u8;
-                    image.data[i * 4 + 3] = (rgba.alpha * 255.) as u8;
                 }
             }
             removed_handles.push(handle_index);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -726,7 +726,7 @@ fn spine_spawn(
                                             empty_mesh(&mut mesh);
                                             let mesh_handle = meshes.add(mesh);
                                             parent.spawn((
-                                                Name::new(format!("spine_mesh {}", index)),
+                                                Name::new(format!("spine_mesh {index}")),
                                                 SpineMesh {
                                                     spine_entity,
                                                     handle: mesh_handle.clone(),

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -10,14 +10,16 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::{
-        mesh::{MeshVertexAttribute, MeshVertexBufferLayoutRef},
         render_resource::{
             AsBindGroup, BlendComponent, BlendFactor, BlendOperation, BlendState,
-            RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError, VertexFormat,
+            RenderPipelineDescriptor, SpecializedMeshPipelineError, VertexFormat,
         },
     },
-    sprite::{AlphaMode2d, Material2d, Material2dKey},
+    shader::ShaderRef,
 };
+use bevy::asset::{uuid_handle};
+use bevy::mesh::{MeshVertexAttribute, MeshVertexBufferLayoutRef};
+use bevy::sprite_render::{Material2d, AlphaMode2d, Material2dKey};
 use rusty_spine::BlendMode;
 
 use crate::{SpineMesh, SpineMeshState, SpineSettings, SpineSystem};
@@ -105,13 +107,13 @@ fn update_materials<T: SpineMaterial>(
                 *material = new_material;
             } else {
                 materials.remove(handle.clone());
-                if let Some(mut entity_commands) = commands.get_entity(mesh_entity) {
+                if let Ok(mut entity_commands) = commands.get_entity(mesh_entity) {
                     entity_commands.remove::<T::MeshMaterial>();
                 }
             }
         } else if let Some(material) = T::update(None, spine_mesh.spine_entity, data, &params) {
             let handle = materials.add(material);
-            if let Some(mut entity_commands) = commands.get_entity(mesh_entity) {
+            if let Ok(mut entity_commands) = commands.get_entity(mesh_entity) {
                 entity_commands
                     .insert(<T::MeshMaterial as From<Handle<T::Material>>>::from(handle));
             }
@@ -126,7 +128,7 @@ pub const DARK_COLOR_ATTRIBUTE: MeshVertexAttribute = MeshVertexAttribute::new(
     VertexFormat::Float32x4,
 );
 
-pub const SHADER_HANDLE: Handle<Shader> = Handle::<Shader>::weak_from_u128(10655547040990968849);
+pub const SHADER_HANDLE: Handle<Shader> = uuid_handle!("b5694dad-2246-5609-85e4-149838ce0219");
 
 /// A [`SystemParam`] to query [`SpineSettings`].
 ///

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -4,22 +4,20 @@
 
 use std::marker::PhantomData;
 
+use bevy::asset::uuid_handle;
+use bevy::mesh::{MeshVertexAttribute, MeshVertexBufferLayoutRef};
+use bevy::sprite_render::{AlphaMode2d, Material2d, Material2dKey};
 use bevy::{
     asset::Asset,
     ecs::system::{StaticSystemParam, SystemParam},
     prelude::*,
     reflect::TypePath,
-    render::{
-        render_resource::{
-            AsBindGroup, BlendComponent, BlendFactor, BlendOperation, BlendState,
-            RenderPipelineDescriptor, SpecializedMeshPipelineError, VertexFormat,
-        },
+    render::render_resource::{
+        AsBindGroup, BlendComponent, BlendFactor, BlendOperation, BlendState,
+        RenderPipelineDescriptor, SpecializedMeshPipelineError, VertexFormat,
     },
     shader::ShaderRef,
 };
-use bevy::asset::{uuid_handle};
-use bevy::mesh::{MeshVertexAttribute, MeshVertexBufferLayoutRef};
-use bevy::sprite_render::{Material2d, AlphaMode2d, Material2dKey};
 use rusty_spine::BlendMode;
 
 use crate::{SpineMesh, SpineMeshState, SpineSettings, SpineSystem};

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -104,18 +104,6 @@ pub struct SpineUiReadyEvent {
     pub proxy_entity: Entity,
 }
 
-#[derive(Component, Clone, Copy, Debug, Default, Reflect)]
-#[reflect(Component, Default)]
-pub struct SpineUiDebugState {
-    pub available_size: Vec2,
-    pub setup_min: Vec2,
-    pub setup_size: Vec2,
-    pub reference_size: Vec2,
-    pub fit_scale: Vec2,
-    pub applied_scale: Vec2,
-    pub translation: Vec2,
-}
-
 #[derive(Component, Clone, Copy)]
 struct SpineUiOwnedBy(Entity);
 
@@ -186,7 +174,6 @@ fn setup_spine_ui_nodes(
                 proxy_entity,
                 camera_entity,
             },
-            SpineUiDebugState::default(),
         ));
 
         if let Some(auto_size) = spine_ui.auto_size {
@@ -216,12 +203,11 @@ fn sync_spine_ui_proxies(
         &InheritedVisibility,
         &SpineUiNode,
         &SpineUiProxy,
-        &mut SpineUiDebugState,
     )>,
     mut proxy_query: Query<(&mut Transform, &mut Visibility, &mut Spine)>,
     mut camera_query: Query<&mut Camera>,
 ) {
-    for (computed_node, inherited_visibility, spine_ui, proxy, mut debug_state) in &mut nodes {
+    for (computed_node, inherited_visibility, spine_ui, proxy) in &mut nodes {
         if let Ok(mut camera) = camera_query.get_mut(proxy.camera_entity) {
             camera.is_active = inherited_visibility.get();
         }
@@ -273,14 +259,6 @@ fn sync_spine_ui_proxies(
             -setup_center.x * applied_scale.x,
             -setup_center.y * applied_scale.y,
         ) + spine_ui.offset;
-
-        debug_state.available_size = available_size;
-        debug_state.setup_min = setup_min;
-        debug_state.setup_size = setup_size;
-        debug_state.reference_size = reference_size;
-        debug_state.fit_scale = fit_scale;
-        debug_state.applied_scale = applied_scale;
-        debug_state.translation = centered_translation;
 
         *proxy_transform = Transform::from_translation(centered_translation.extend(0.0))
             .with_scale(applied_scale.extend(1.0));
@@ -338,7 +316,7 @@ fn cleanup_spine_ui_proxies(
         commands.entity(entity).despawn();
 
         if let Ok(mut owner_commands) = commands.get_entity(owner.0) {
-            owner_commands.remove::<(SpineUiProxy, ViewportNode, SpineUiDebugState)>();
+            owner_commands.remove::<(SpineUiProxy, ViewportNode)>();
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -303,10 +303,22 @@ fn forward_spine_ui_ready_events(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn cleanup_spine_ui_proxies(
     mut commands: Commands,
     owners: Query<(Entity, &SpineUiOwnedBy)>,
     ui_nodes: Query<(), With<SpineUiNode>>,
+    stale_ui_nodes: Query<
+        Entity,
+        (
+            Without<SpineUiNode>,
+            Or<(
+                With<SpineUiProxy>,
+                With<ViewportNode>,
+                With<SpineUiDebugState>,
+            )>,
+        ),
+    >,
 ) {
     for (entity, owner) in &owners {
         if ui_nodes.contains(owner.0) {
@@ -318,5 +330,11 @@ fn cleanup_spine_ui_proxies(
         if let Ok(mut owner_commands) = commands.get_entity(owner.0) {
             owner_commands.remove::<(SpineUiProxy, ViewportNode)>();
         }
+    }
+
+    for entity in &stale_ui_nodes {
+        commands
+            .entity(entity)
+            .remove::<(SpineUiProxy, ViewportNode, SpineUiDebugState)>();
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -16,16 +16,23 @@ pub struct SpineUiPlugin;
 
 impl Plugin for SpineUiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<SpineUiReadyEvent>().add_systems(
-            Update,
-            (
-                setup_spine_ui_nodes,
-                update_spine_ui_content_size,
-                sync_spine_ui_proxies,
-                forward_spine_ui_ready_events,
-                cleanup_spine_ui_proxies,
-            ),
-        );
+        app.register_type::<SpineUiNode>()
+            .register_type::<SpineUiFit>()
+            .register_type::<SpineUiAnimation>()
+            .register_type::<SpineUiProxy>()
+            .register_type::<SpineUiDebugState>()
+            .register_type::<SpineUiOwnedBy>()
+            .add_message::<SpineUiReadyEvent>()
+            .add_systems(
+                Update,
+                (
+                    setup_spine_ui_nodes,
+                    update_spine_ui_content_size,
+                    sync_spine_ui_proxies,
+                    forward_spine_ui_ready_events,
+                    cleanup_spine_ui_proxies,
+                ),
+            );
     }
 }
 
@@ -104,7 +111,8 @@ pub struct SpineUiReadyEvent {
     pub proxy_entity: Entity,
 }
 
-#[derive(Component, Clone, Copy)]
+#[derive(Component, Clone, Copy, Reflect)]
+#[reflect(Component, Clone)]
 struct SpineUiOwnedBy(Entity);
 
 #[allow(clippy::type_complexity)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,344 @@
+use bevy::{
+    asset::RenderAssetUsages,
+    camera::{ClearColorConfig, RenderTarget},
+    image::Image,
+    prelude::*,
+    render::render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
+    ui::{widget::ViewportNode, ContentSize},
+};
+
+use crate::{
+    Crossfades, SkeletonController, SkeletonDataHandle, Spine, SpineBundle, SpineLoader,
+    SpineReadyEvent, SpineSettings,
+};
+
+pub struct SpineUiPlugin;
+
+impl Plugin for SpineUiPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_message::<SpineUiReadyEvent>().add_systems(
+            Update,
+            (
+                setup_spine_ui_nodes,
+                update_spine_ui_content_size,
+                sync_spine_ui_proxies,
+                forward_spine_ui_ready_events,
+                cleanup_spine_ui_proxies,
+            ),
+        );
+    }
+}
+
+#[derive(Component, Clone, Debug, Reflect)]
+#[reflect(Component, Default)]
+pub struct SpineUiNode {
+    pub fit: SpineUiFit,
+    pub auto_size: Option<Vec2>,
+    pub reference_size: Option<Vec2>,
+    pub offset: Vec2,
+    pub scale: f32,
+    pub flip_y: bool,
+    pub tint: Color,
+    pub animation: Option<SpineUiAnimation>,
+}
+
+impl Default for SpineUiNode {
+    fn default() -> Self {
+        Self {
+            fit: SpineUiFit::Contain,
+            auto_size: Some(Vec2::new(300.0, 420.0)),
+            reference_size: None,
+            offset: Vec2::ZERO,
+            scale: 1.0,
+            flip_y: false,
+            tint: Color::WHITE,
+            animation: None,
+        }
+    }
+}
+
+#[derive(Component, Clone, Copy, Debug, Default, Reflect)]
+#[reflect(Component, Default)]
+pub enum SpineUiFit {
+    #[default]
+    Contain,
+    Cover,
+    Fill,
+    None,
+}
+
+#[derive(Clone, Debug, Reflect)]
+pub struct SpineUiAnimation {
+    pub name: String,
+    pub repeat: bool,
+}
+
+impl SpineUiAnimation {
+    pub fn looping(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            repeat: true,
+        }
+    }
+}
+
+#[derive(Bundle, Default)]
+pub struct SpineUiBundle {
+    pub node: Node,
+    pub spine_ui: SpineUiNode,
+    pub skeleton: SkeletonDataHandle,
+    pub crossfades: Crossfades,
+    pub settings: SpineSettings,
+}
+
+#[derive(Component, Clone, Copy, Debug, Reflect)]
+#[reflect(Component)]
+pub struct SpineUiProxy {
+    pub proxy_entity: Entity,
+    pub camera_entity: Entity,
+}
+
+#[derive(Message, Clone, Copy, Debug)]
+pub struct SpineUiReadyEvent {
+    pub entity: Entity,
+    pub proxy_entity: Entity,
+}
+
+#[derive(Component, Clone, Copy, Debug, Default, Reflect)]
+#[reflect(Component, Default)]
+pub struct SpineUiDebugState {
+    pub available_size: Vec2,
+    pub setup_min: Vec2,
+    pub setup_size: Vec2,
+    pub reference_size: Vec2,
+    pub fit_scale: Vec2,
+    pub applied_scale: Vec2,
+    pub translation: Vec2,
+}
+
+#[derive(Component, Clone, Copy)]
+struct SpineUiOwnedBy(Entity);
+
+#[allow(clippy::type_complexity)]
+fn setup_spine_ui_nodes(
+    mut commands: Commands,
+    mut images: ResMut<Assets<Image>>,
+    nodes: Query<
+        (
+            Entity,
+            &SkeletonDataHandle,
+            &Crossfades,
+            &SpineSettings,
+            &SpineUiNode,
+        ),
+        (Added<SpineUiNode>, Without<SpineUiProxy>),
+    >,
+) {
+    for (entity, skeleton, crossfades, settings, spine_ui) in &nodes {
+        let mut image = Image::new_uninit(
+            Extent3d {
+                width: 1,
+                height: 1,
+                ..default()
+            },
+            TextureDimension::D2,
+            TextureFormat::Bgra8UnormSrgb,
+            RenderAssetUsages::all(),
+        );
+        image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING
+            | TextureUsages::COPY_DST
+            | TextureUsages::RENDER_ATTACHMENT;
+        let image_handle = images.add(image);
+
+        let camera_entity = commands
+            .spawn((
+                Camera2d,
+                Camera {
+                    order: -1,
+                    clear_color: ClearColorConfig::Custom(Color::NONE),
+                    target: RenderTarget::Image(image_handle.into()),
+                    ..default()
+                },
+                SpineUiOwnedBy(entity),
+            ))
+            .id();
+
+        let mut proxy_settings = *settings;
+        proxy_settings.mesh_type = crate::SpineMeshType::Mesh2D;
+
+        let proxy_entity = commands
+            .spawn((
+                SpineBundle {
+                    skeleton: skeleton.clone(),
+                    crossfades: crossfades.clone(),
+                    settings: proxy_settings,
+                    loader: SpineLoader::without_children(),
+                    ..default()
+                },
+                SpineUiOwnedBy(entity),
+            ))
+            .id();
+
+        let mut entity_commands = commands.entity(entity);
+        entity_commands.insert((
+            ViewportNode::new(camera_entity),
+            SpineUiProxy {
+                proxy_entity,
+                camera_entity,
+            },
+            SpineUiDebugState::default(),
+        ));
+
+        if let Some(auto_size) = spine_ui.auto_size {
+            entity_commands.insert(ContentSize::fixed_size(auto_size));
+        }
+    }
+}
+
+fn update_spine_ui_content_size(
+    mut commands: Commands,
+    nodes: Query<(Entity, &SpineUiNode), Changed<SpineUiNode>>,
+) {
+    for (entity, spine_ui) in &nodes {
+        if let Some(auto_size) = spine_ui.auto_size {
+            commands
+                .entity(entity)
+                .insert(ContentSize::fixed_size(auto_size));
+        } else {
+            commands.entity(entity).remove::<ContentSize>();
+        }
+    }
+}
+
+fn sync_spine_ui_proxies(
+    mut nodes: Query<(
+        &ComputedNode,
+        &InheritedVisibility,
+        &SpineUiNode,
+        &SpineUiProxy,
+        &mut SpineUiDebugState,
+    )>,
+    mut proxy_query: Query<(&mut Transform, &mut Visibility, &mut Spine)>,
+    mut camera_query: Query<&mut Camera>,
+) {
+    for (computed_node, inherited_visibility, spine_ui, proxy, mut debug_state) in &mut nodes {
+        if let Ok(mut camera) = camera_query.get_mut(proxy.camera_entity) {
+            camera.is_active = inherited_visibility.get();
+        }
+
+        let Ok((mut proxy_transform, mut proxy_visibility, mut spine)) =
+            proxy_query.get_mut(proxy.proxy_entity)
+        else {
+            continue;
+        };
+
+        let Spine(SkeletonController { skeleton, .. }) = spine.as_mut();
+        let [r, g, b, a] = spine_ui.tint.to_linear().to_f32_array();
+        *skeleton.color_mut() = rusty_spine::Color::new_rgba(r, g, b, a);
+
+        let data = skeleton.data();
+        let setup_min = Vec2::new(data.x(), data.y());
+        let setup_size = Vec2::new(data.width(), data.height()).max(Vec2::ONE);
+        let setup_center = setup_min + setup_size * 0.5;
+
+        *proxy_visibility = if inherited_visibility.get() {
+            Visibility::Visible
+        } else {
+            Visibility::Hidden
+        };
+
+        let available_size = computed_node.size().max(Vec2::ONE);
+        let reference_size = spine_ui.reference_size.unwrap_or(setup_size).max(Vec2::ONE);
+        let fit_scale = available_size / reference_size;
+
+        let mut applied_scale = match spine_ui.fit {
+            SpineUiFit::Contain => {
+                let s = fit_scale.x.min(fit_scale.y) * spine_ui.scale;
+                Vec2::new(s, s)
+            }
+            SpineUiFit::Cover => {
+                let s = fit_scale.x.max(fit_scale.y) * spine_ui.scale;
+                Vec2::new(s, s)
+            }
+            SpineUiFit::Fill => {
+                Vec2::new(fit_scale.x * spine_ui.scale, fit_scale.y * spine_ui.scale)
+            }
+            SpineUiFit::None => Vec2::splat(spine_ui.scale),
+        };
+        if spine_ui.flip_y {
+            applied_scale.y *= -1.0;
+        }
+
+        let centered_translation = Vec2::new(
+            -setup_center.x * applied_scale.x,
+            -setup_center.y * applied_scale.y,
+        ) + spine_ui.offset;
+
+        debug_state.available_size = available_size;
+        debug_state.setup_min = setup_min;
+        debug_state.setup_size = setup_size;
+        debug_state.reference_size = reference_size;
+        debug_state.fit_scale = fit_scale;
+        debug_state.applied_scale = applied_scale;
+        debug_state.translation = centered_translation;
+
+        *proxy_transform = Transform::from_translation(centered_translation.extend(0.0))
+            .with_scale(applied_scale.extend(1.0));
+    }
+}
+
+fn forward_spine_ui_ready_events(
+    mut spine_ready_events: MessageReader<SpineReadyEvent>,
+    mut spine_ui_ready_events: MessageWriter<SpineUiReadyEvent>,
+    owner_query: Query<&SpineUiOwnedBy>,
+    node_query: Query<&SpineUiNode>,
+    mut spine_query: Query<&mut Spine>,
+) {
+    for event in spine_ready_events.read() {
+        let Ok(owner) = owner_query.get(event.entity) else {
+            continue;
+        };
+
+        if let Ok(spine_ui) = node_query.get(owner.0) {
+            if let Some(animation) = spine_ui.animation.as_ref() {
+                if let Ok(mut spine) = spine_query.get_mut(event.entity) {
+                    let Spine(SkeletonController {
+                        animation_state,
+                        skeleton,
+                        ..
+                    }) = spine.as_mut();
+                    let [r, g, b, a] = spine_ui.tint.to_linear().to_f32_array();
+                    *skeleton.color_mut() = rusty_spine::Color::new_rgba(r, g, b, a);
+                    let _ = animation_state.set_animation_by_name(
+                        0,
+                        animation.name.as_str(),
+                        animation.repeat,
+                    );
+                }
+            }
+        }
+
+        spine_ui_ready_events.write(SpineUiReadyEvent {
+            entity: owner.0,
+            proxy_entity: event.entity,
+        });
+    }
+}
+
+fn cleanup_spine_ui_proxies(
+    mut commands: Commands,
+    owners: Query<(Entity, &SpineUiOwnedBy)>,
+    ui_nodes: Query<(), With<SpineUiNode>>,
+) {
+    for (entity, owner) in &owners {
+        if ui_nodes.contains(owner.0) {
+            continue;
+        }
+
+        commands.entity(entity).despawn();
+
+        if let Ok(mut owner_commands) = commands.get_entity(owner.0) {
+            owner_commands.remove::<(SpineUiProxy, ViewportNode, SpineUiDebugState)>();
+        }
+    }
+}


### PR DESCRIPTION
- Migrates the crate to Bevy 0.18 and updates the API to the newer required-components approach.
- Adds Spine UI node rendering support with a dedicated UI showcase example.
- Fixes culling correctness by updating dynamic Spine AABBs so frustum behavior matches animated meshes.
- Includes general polish across examples/docs plus lint/format cleanup.
- closes #37, closes #33, closes #11, closes #36, closes #35, closes #34, closes #29