### PR TITLE
Fix CI stability and doc-check issues on Bevy 0.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.89.0
       - name: Install native Linux deps
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- check
@@ -23,6 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.89.0
           targets: wasm32-unknown-unknown
       - run: cargo run -p ci -- wasm-check
 
@@ -32,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.89.0
       - name: Install native Linux deps
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- example-check
@@ -42,6 +47,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+          toolchain: 1.89.0
       - name: Install native Linux deps
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- fmt
@@ -52,6 +60,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.89.0
       - name: Install native Linux deps
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- test
@@ -62,6 +72,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.89.0
       - name: Install native Linux deps
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- doc-test
@@ -72,6 +84,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.89.0
       - name: Install native Linux deps
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- doc-check
@@ -82,6 +96,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          toolchain: 1.89.0
       - name: Install native Linux deps
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Install native Linux deps
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- check
 
   wasm-check:
@@ -32,8 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Install native Linux deps
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- example-check
 
   fmt:
@@ -42,8 +42,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Install native Linux deps
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- fmt
 
   test:
@@ -52,8 +52,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Install native Linux deps
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- test
 
   doc-test:
@@ -62,8 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Install native Linux deps
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- doc-test
 
   doc-check:
@@ -72,8 +72,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Install native Linux deps
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- doc-check
 
   clippy:
@@ -82,6 +82,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Install native Linux deps
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - run: cargo run -p ci -- clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://github.com/jabuwu/bevy_spine"
 repository = "https://github.com/jabuwu/bevy_spine"
 readme = "readme.md"
 license-file = "LICENSE"
+rust-version = "1.89"
 exclude = ["assets/*"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ ui = ["bevy/bevy_ui"]
 [dependencies]
 rusty_spine = "0.8"
 bevy = { version = "0.18", default-features = false, features = [
+  "bevy_log",
   "bevy_render",
   "bevy_asset",
   "bevy_sprite",

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -176,7 +176,7 @@ impl SkeletonData {
     /// }
     /// ```
     ///
-    /// For more information on the loading process, see [`SkeletonDataHandle`].
+    /// For more information on the loading process, see [`crate::SkeletonDataHandle`].
     pub fn new_from_json(json: Handle<SkeletonJson>, atlas: Handle<Atlas>) -> Self {
         Self {
             atlas_handle: atlas,
@@ -210,7 +210,7 @@ impl SkeletonData {
     /// }
     /// ```
     ///
-    /// For more information on the loading process, see [`SkeletonDataHandle`].
+    /// For more information on the loading process, see [`crate::SkeletonDataHandle`].
     pub fn new_from_binary(binary: Handle<SkeletonBinary>, atlas: Handle<Atlas>) -> Self {
         Self {
             atlas_handle: atlas,

--- a/src/crossfades.rs
+++ b/src/crossfades.rs
@@ -6,7 +6,7 @@ use rusty_spine::AnimationStateData;
 /// Crossfade data to apply to [`rusty_spine::AnimationStateData`]. Allows automated crossfading
 /// between animations.
 ///
-/// Add this alongside [`SkeletonDataHandle`] when spawning a Spine entity:
+/// Add this alongside [`crate::SkeletonDataHandle`] when spawning a Spine entity:
 ///
 /// ```
 /// # use bevy::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub enum SpineSystem {
     /// Spawns helper entities associated with entities containing [`SkeletonDataHandle`] for
     /// drawing meshes and (optionally) adding bone entities (see [`SpineLoader`]).
     Spawn,
-    /// An [`apply_deferred`] to load the spine helper entities this frame.
+    /// An [`bevy::ecs::schedule::ApplyDeferred`] to load the spine helper entities this frame.
     SpawnFlush,
     /// Sends [`SpineReadyEvent`] after [`SpineSystem::SpawnFlush`], indicating [`Spine`]
     /// components on newly spawned entities can now be interacted with.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,11 @@
 use bevy::{
     asset::RenderAssetUsages,
-    camera::{ClearColorConfig, RenderTarget, visibility::RenderLayers},
+    camera::{visibility::RenderLayers, ClearColorConfig, RenderTarget},
     image::Image,
     platform::collections::{HashMap, HashSet},
     prelude::*,
     render::render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
-    ui::{ContentSize, widget::ViewportNode},
+    ui::{widget::ViewportNode, ContentSize},
 };
 
 use crate::{

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,11 @@
 use bevy::{
     asset::RenderAssetUsages,
-    camera::{visibility::RenderLayers, ClearColorConfig, RenderTarget},
+    camera::{ClearColorConfig, RenderTarget, visibility::RenderLayers},
     image::Image,
     platform::collections::{HashMap, HashSet},
     prelude::*,
     render::render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
-    ui::{widget::ViewportNode, ContentSize},
+    ui::{ContentSize, widget::ViewportNode},
 };
 
 use crate::{


### PR DESCRIPTION
## Summary
- Install required Linux native dependencies in CI (`libwayland-dev`, `libxkbcommon-dev`, plus existing audio/udev deps) and use non-interactive apt installs so local/CI runs do not abort.
- Pin Rust to 1.89.0 in CI and declare crate MSRV (`rust-version = \"1.89\"`) to align with Bevy 0.18 requirements.
- Fix doc-check and lint friction by enabling Bevy logging usage in UI warnings, resolving rustdoc intra-doc links, and applying rustfmt cleanup.

## Reference
- Mirrors the approach from https://github.com/jabuwu/rusty_spine/pull/35 (adapted to this repo's Bevy/MSRV requirements).