### PR TITLE
Update to Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_spine"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 description = "Spine plugin for Bevy utilizing rusty_spine"
 homepage = "https://github.com/jabuwu/bevy_spine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/jabuwu/bevy_spine"
 repository = "https://github.com/jabuwu/bevy_spine"
 readme = "readme.md"
 license-file = "LICENSE"
-rust-version = "1.89"
+rust-version = "1.95"
 exclude = ["assets/*"]
 
 [features]
@@ -16,7 +16,7 @@ ui = ["bevy/bevy_ui"]
 
 [dependencies]
 rusty_spine = "0.8"
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19.0", default-features = false, features = [
   "bevy_log",
   "bevy_render",
   "bevy_asset",
@@ -28,7 +28,7 @@ thiserror = "2.0.18"
 
 [dev-dependencies]
 lerp = "0.5"
-bevy = { version = "0.18", default-features = true, features = [
+bevy = { version = "0.19.0", default-features = true, features = [
   "bevy_ui_debug",
 ] }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 0.12.0
+- Update to Bevy 0.19.
+- Bump minimum Rust toolchain to 1.95.0.
+- Update examples and material handling for Bevy 0.19 API changes.
+
 # 0.11.0
 - Update to Bevy 0.18.
 - Bump minimum Rust toolchain to 1.89.0.

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -55,7 +55,7 @@ fn setup(
     commands.spawn((
         PointLight {
             intensity: 1500.0,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(4.0, 8.0, 4.0),

--- a/examples/ik.rs
+++ b/examples/ik.rs
@@ -53,7 +53,7 @@ fn on_spawn(
                 animation_state,
                 ..
             }) = spine.as_mut();
-            skeleton.set_scale(Vec2::splat(1.));
+            skeleton.set_scale([1., 1.]);
             let _ = animation_state.set_animation_by_name(0, "run", true);
             let _ = animation_state.set_animation_by_name(1, "aim", true);
             let _ = animation_state.set_animation_by_name(2, "shoot", true);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -42,7 +42,7 @@ fn on_spawn(
                 animation_state,
                 ..
             }) = spine.as_mut();
-            skeleton.set_scale(Vec2::splat(0.5));
+            skeleton.set_scale([0.5, 0.5]);
             let _ = animation_state.set_animation_by_name(0, "portal", true);
         }
     }

--- a/examples/ui_showcase.rs
+++ b/examples/ui_showcase.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, ui_render::UiDebugOptions};
+use bevy::{prelude::*, ui_render::GlobalUiDebugOptions};
 use bevy_spine::{
     SkeletonData, SpinePlugin, SpineUiAnimation, SpineUiFit, SpineUiNode, SpineUiSkeleton,
 };
@@ -211,7 +211,7 @@ fn apply_showcase_state(
 
 fn toggle_ui_debug_overlay(
     input: Res<ButtonInput<KeyCode>>,
-    mut debug_options: ResMut<UiDebugOptions>,
+    mut debug_options: ResMut<GlobalUiDebugOptions>,
 ) {
     if input.just_pressed(KeyCode::F1) {
         debug_options.toggle();

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,8 @@ A Bevy Plugin for [Spine](http://esotericsoftware.com/), utilizing [rusty_spine]
 
 ```
 [dependencies]
-bevy = "0.18"
-bevy_spine = "0.11"
+bevy = "0.19"
+bevy_spine = "0.12"
 ```
 
 [See online demos!](https://jabuwu.github.io/bevy_spine_demos/) ([source repo](https://github.com/jabuwu/bevy_spine_demos))
@@ -14,6 +14,7 @@ bevy_spine = "0.11"
 
 | bevy_spine       | rusty_spine | bevy | spine |
 | ---------------- | ----------- | ---- | ----- |
+| 0.12             | 0.8         | 0.19 | 4.2   |
 | 0.11             | 0.8         | 0.18 | 4.2   |
 | 0.10             | 0.8         | 0.14 | 4.2   |
 | 0.9              | 0.8         | 0.13 | 4.2   |

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -973,7 +973,7 @@ fn spine_update_meshes(
                     Mesh3d(spine_mesh.handle.clone()),
                     Mesh3d
                 );
-                let Some(mesh) = meshes.get_mut(&spine_mesh.handle) else {
+                let Some(mut mesh) = meshes.get_mut(&spine_mesh.handle) else {
                     continue;
                 };
                 let mut empty = true;
@@ -1098,7 +1098,7 @@ fn spine_update_meshes(
                 }
                 if empty {
                     spine_mesh.state = SpineMeshState::Empty;
-                    empty_mesh(mesh);
+                    empty_mesh(&mut mesh);
                     write_spine_mesh_aabb(
                         &mut commands,
                         spine_mesh_entity,
@@ -1157,7 +1157,7 @@ fn adjust_spine_textures(
     }
     let mut removed_handles = vec![];
     for (handle_index, (handle, handle_config)) in local.handles.iter().enumerate() {
-        if let Some(image) = images.get_mut(handle) {
+        if let Some(mut image) = images.get_mut(handle) {
             fn convert_filter(filter: AtlasFilter) -> ImageFilterMode {
                 match filter {
                     AtlasFilter::Nearest => ImageFilterMode::Nearest,

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -93,20 +93,35 @@ fn update_materials<T: SpineMaterial>(
         let SpineMeshState::Renderable { info: data } = spine_mesh.state.clone() else {
             continue;
         };
-        if let Some((material, handle)) =
-            material_handle.and_then(|handle| materials.get_mut(handle.clone()).zip(Some(handle)))
-        {
-            if let Some(new_material) = T::update(
-                Some(material.clone()),
-                spine_mesh.spine_entity,
-                data,
-                &params,
-            ) {
-                *material = new_material;
-            } else {
+        if let Some(handle) = material_handle {
+            let (remove_material, create_material) = match materials.get_mut(handle.clone()) {
+                Some(mut material) => match T::update(
+                    Some(material.clone()),
+                    spine_mesh.spine_entity,
+                    data.clone(),
+                    &params,
+                ) {
+                    Some(new_material) => {
+                        *material = new_material;
+                        (false, false)
+                    }
+                    None => (true, false),
+                },
+                None => (false, true),
+            };
+
+            if remove_material {
                 materials.remove(handle.clone());
                 if let Ok(mut entity_commands) = commands.get_entity(mesh_entity) {
                     entity_commands.remove::<T::MeshMaterial>();
+                }
+            } else if create_material
+                && let Some(material) = T::update(None, spine_mesh.spine_entity, data, &params)
+            {
+                let handle = materials.add(material);
+                if let Ok(mut entity_commands) = commands.get_entity(mesh_entity) {
+                    entity_commands
+                        .insert(<T::MeshMaterial as From<Handle<T::Material>>>::from(handle));
                 }
             }
         } else if let Some(material) = T::update(None, spine_mesh.spine_entity, data, &params) {

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -94,7 +94,8 @@ fn update_materials<T: SpineMaterial>(
             continue;
         };
         if let Some(handle) = material_handle {
-            let (remove_material, create_material) = match materials.get_mut(handle.clone()) {
+            let mut remove_material = false;
+            let material_to_add = match materials.get_mut(handle.clone()) {
                 Some(mut material) => match T::update(
                     Some(material.clone()),
                     spine_mesh.spine_entity,
@@ -103,11 +104,14 @@ fn update_materials<T: SpineMaterial>(
                 ) {
                     Some(new_material) => {
                         *material = new_material;
-                        (false, false)
+                        None
                     }
-                    None => (true, false),
+                    None => {
+                        remove_material = true;
+                        None
+                    }
                 },
-                None => (false, true),
+                None => T::update(None, spine_mesh.spine_entity, data, &params),
             };
 
             if remove_material {
@@ -115,9 +119,7 @@ fn update_materials<T: SpineMaterial>(
                 if let Ok(mut entity_commands) = commands.get_entity(mesh_entity) {
                     entity_commands.remove::<T::MeshMaterial>();
                 }
-            } else if create_material
-                && let Some(material) = T::update(None, spine_mesh.spine_entity, data, &params)
-            {
+            } else if let Some(material) = material_to_add {
                 let handle = materials.add(material);
                 if let Ok(mut entity_commands) = commands.get_entity(mesh_entity) {
                     entity_commands


### PR DESCRIPTION
Updates bevy_spine for Bevy 0.19 and bumps the release notes for the new version.

Closes #40.

Checks:
- cargo test --all-features --all-targets --no-run
- cargo clippy --all-features --all-targets -- -D warnings