### PR TITLE
Add direct Spine rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,16 @@ ui = ["bevy/bevy_ui"]
 
 [dependencies]
 rusty_spine = "0.8"
+bytemuck = "1.24.0"
 bevy = { version = "0.19.0", default-features = false, features = [
   "bevy_log",
   "bevy_render",
   "bevy_asset",
+  "bevy_pbr",
   "bevy_sprite",
   "bevy_sprite_render",
 ] }
+bevy_sprite_render = { version = "0.19.0", default-features = false }
 glam = { version = "0.30", features = ["mint"] }
 thiserror = "2.0.18"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ["assets/*"]
 
 [features]
 default = []
+3d = ["bevy/bevy_pbr"]
 ui = ["bevy/bevy_ui"]
 
 [dependencies]
@@ -21,7 +22,6 @@ bevy = { version = "0.19.0", default-features = false, features = [
   "bevy_log",
   "bevy_render",
   "bevy_asset",
-  "bevy_pbr",
   "bevy_sprite",
   "bevy_sprite_render",
 ] }
@@ -38,6 +38,10 @@ bevy = { version = "0.19.0", default-features = true, features = [
 [workspace]
 resolver = "2"
 members = ["ci"]
+
+[[example]]
+name = "3d"
+required-features = ["3d"]
 
 [[example]]
 name = "ui_showcase"

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -80,6 +80,7 @@ fn setup(
         SpineSettings {
             default_materials: false,
             mesh_type: SpineMeshType::Mesh3D,
+            direct_rendering: true,
             ..Default::default()
         },
     ));

--- a/src/direct_render.rs
+++ b/src/direct_render.rs
@@ -17,6 +17,7 @@ use bevy::{
         view::{ExtractedView, RenderVisibleEntities},
     },
 };
+#[cfg(feature = "3d")]
 use bevy::{
     core_pipeline::core_3d::Transparent3d,
     material::RenderPhaseType,
@@ -165,6 +166,7 @@ impl Plugin for SpineDirectRenderPlugin {
                     prepare_spine_direct_mesh_buffers.in_set(RenderSystems::PrepareResources),
                 );
 
+            #[cfg(feature = "3d")]
             render_app
                 .add_render_command::<Transparent3d, DrawSpineDirectMaterial3d>()
                 .add_systems(
@@ -213,6 +215,7 @@ type DrawSpineDirectMaterial2d<M> = (
     DrawSpineDirectMesh,
 );
 
+#[cfg(feature = "3d")]
 type DrawSpineDirectMaterial3d = (
     SetItemPipeline,
     SetMeshViewBindGroup<0>,
@@ -387,6 +390,7 @@ fn queue_spine_direct_material2d_meshes<M: Material2d>(
     }
 }
 
+#[cfg(feature = "3d")]
 fn queue_spine_direct_material3d_meshes(
     render_materials: Option<Res<ErasedRenderAssets<PreparedMaterial>>>,
     render_material_instances: Option<Res<RenderMaterialInstances>>,

--- a/src/direct_render.rs
+++ b/src/direct_render.rs
@@ -1,0 +1,495 @@
+use std::{hash::Hash, marker::PhantomData, mem::size_of_val, ops::Range};
+
+use bevy::{
+    core_pipeline::core_2d::Transparent2d,
+    prelude::*,
+    render::{
+        Render, RenderApp, RenderSystems,
+        extract_component::{ExtractComponent, ExtractComponentPlugin},
+        render_asset::{RenderAssets, prepare_assets},
+        render_phase::{
+            AddRenderCommand, DrawFunctions, PhaseItemExtraIndex, RenderCommand,
+            RenderCommandResult, SetItemPipeline, TrackedRenderPass, ViewSortedRenderPhases,
+        },
+        render_resource::{Buffer, BufferDescriptor, BufferUsages, IndexFormat},
+        renderer::{RenderDevice, RenderQueue},
+        sync_world::{MainEntity, MainEntityHashMap},
+        view::{ExtractedView, RenderVisibleEntities},
+    },
+};
+use bevy::{
+    core_pipeline::core_3d::Transparent3d,
+    material::RenderPhaseType,
+    pbr::{
+        MATERIAL_BIND_GROUP_INDEX as MATERIAL_3D_BIND_GROUP_INDEX, PreparedMaterial,
+        RenderMaterialInstances, SetMaterialBindGroup, SetMeshBindGroup, SetMeshViewBindGroup,
+        SetMeshViewBindingArrayBindGroup, queue_material_meshes,
+    },
+    render::erased_render_asset::ErasedRenderAssets,
+};
+use bevy_sprite_render::{
+    AlphaMode2d, MATERIAL_2D_BIND_GROUP_INDEX, Material2d, PreparedMaterial2d,
+    RenderMaterial2dInstances, SetMaterial2dBindGroup, SetMesh2dBindGroup, SetMesh2dViewBindGroup,
+    queue_material2d_meshes,
+};
+
+use crate::materials::{
+    SpineAdditiveMaterial, SpineAdditivePmaMaterial, SpineMultiplyMaterial,
+    SpineMultiplyPmaMaterial, SpineNormalMaterial, SpineNormalPmaMaterial, SpineScreenMaterial,
+    SpineScreenPmaMaterial,
+};
+
+const MIN_BUFFER_CAPACITY: u64 = 4096;
+
+/// CPU-side Spine geometry extracted to the render world for direct GPU upload.
+#[derive(Component, Clone, Default, ExtractComponent)]
+pub(crate) struct SpineDirectMesh {
+    vertices: Vec<SpineDirectVertex>,
+    indices: Vec<u16>,
+}
+
+impl SpineDirectMesh {
+    pub(crate) fn write(
+        &mut self,
+        mesh_entity: Entity,
+        vertices: &[[f32; 2]],
+        indices: &[u16],
+        uvs: &[[f32; 2]],
+        colors: &[[f32; 4]],
+        dark_colors: &[[f32; 4]],
+    ) -> bool {
+        let vertex_count = vertices.len();
+        if uvs.len() != vertex_count {
+            warn!(
+                entity = ?mesh_entity,
+                "Spine renderable has {vertex_count} vertices but {} uvs; skipping direct mesh update",
+                uvs.len()
+            );
+            self.clear();
+            return false;
+        }
+        if colors.len() != vertex_count || dark_colors.len() != vertex_count {
+            warn!(
+                entity = ?mesh_entity,
+                "Spine renderable has {vertex_count} vertices but {} colors and {} dark colors; skipping direct mesh update",
+                colors.len(),
+                dark_colors.len()
+            );
+            self.clear();
+            return false;
+        }
+        if indices
+            .iter()
+            .any(|index| usize::from(*index) >= vertex_count)
+        {
+            warn!(
+                entity = ?mesh_entity,
+                "Spine renderable has an index outside its {vertex_count} vertices; skipping direct mesh update"
+            );
+            self.clear();
+            return false;
+        }
+
+        self.vertices.clear();
+        self.vertices
+            .extend(vertices.iter().zip(uvs).zip(colors).zip(dark_colors).map(
+                |(((position, uv), color), dark_color)| SpineDirectVertex {
+                    position: [position[0], position[1], 0.0],
+                    normal: [0.0, 0.0, 0.0],
+                    uv: *uv,
+                    color: *color,
+                    dark_color: *dark_color,
+                },
+            ));
+
+        self.indices.clear();
+        self.indices.extend_from_slice(indices);
+        true
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.vertices.clear();
+        self.indices.clear();
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct SpineDirectVertex {
+    position: [f32; 3],
+    normal: [f32; 3],
+    uv: [f32; 2],
+    color: [f32; 4],
+    dark_color: [f32; 4],
+}
+
+#[derive(Resource, Default)]
+struct SpineDirectMeshBuffers {
+    vertex_buffer: Option<Buffer>,
+    index_buffer: Option<Buffer>,
+    vertex_capacity: u64,
+    index_capacity: u64,
+    meshes: MainEntityHashMap<PackedSpineDirectMesh>,
+    vertices: Vec<SpineDirectVertex>,
+    indices: Vec<u16>,
+}
+
+struct PackedSpineDirectMesh {
+    indices: Range<u32>,
+    vertex_base: i32,
+}
+
+/// Direct-render support for built-in Spine materials.
+pub(crate) struct SpineDirectRenderPlugin;
+
+impl Plugin for SpineDirectRenderPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins((
+            SpineDirectMaterial2dPlugin::<SpineNormalMaterial>::default(),
+            SpineDirectMaterial2dPlugin::<SpineAdditiveMaterial>::default(),
+            SpineDirectMaterial2dPlugin::<SpineMultiplyMaterial>::default(),
+            SpineDirectMaterial2dPlugin::<SpineScreenMaterial>::default(),
+            SpineDirectMaterial2dPlugin::<SpineNormalPmaMaterial>::default(),
+            SpineDirectMaterial2dPlugin::<SpineAdditivePmaMaterial>::default(),
+            SpineDirectMaterial2dPlugin::<SpineMultiplyPmaMaterial>::default(),
+            SpineDirectMaterial2dPlugin::<SpineScreenPmaMaterial>::default(),
+        ));
+
+        app.add_plugins(ExtractComponentPlugin::<SpineDirectMesh>::extract_visible());
+
+        if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app
+                .init_resource::<SpineDirectMeshBuffers>()
+                .add_systems(
+                    Render,
+                    prepare_spine_direct_mesh_buffers.in_set(RenderSystems::PrepareResources),
+                );
+
+            render_app
+                .add_render_command::<Transparent3d, DrawSpineDirectMaterial3d>()
+                .add_systems(
+                    Render,
+                    queue_spine_direct_material3d_meshes
+                        .in_set(RenderSystems::QueueMeshes)
+                        .after(queue_material_meshes),
+                );
+        }
+    }
+}
+
+/// Queues direct-rendered Spine meshes that use alpha-blended material `M`.
+///
+/// Built-in Spine materials are registered by [`SpinePlugin`](crate::SpinePlugin). Custom 2D
+/// materials also need Bevy's [`Material2dPlugin`](bevy::sprite_render::Material2dPlugin) and
+/// [`SpineMaterialPlugin`](crate::materials::SpineMaterialPlugin).
+#[derive(Default)]
+pub struct SpineDirectMaterial2dPlugin<M: Material2d>(PhantomData<M>);
+
+impl<M> Plugin for SpineDirectMaterial2dPlugin<M>
+where
+    M: Material2d,
+    M::Data: PartialEq + Eq + Hash + Clone,
+{
+    fn build(&self, app: &mut App) {
+        if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app
+                .add_render_command::<Transparent2d, DrawSpineDirectMaterial2d<M>>()
+                .add_systems(
+                    Render,
+                    queue_spine_direct_material2d_meshes::<M>
+                        .in_set(RenderSystems::QueueMeshes)
+                        .after(prepare_assets::<PreparedMaterial2d<M>>)
+                        .after(queue_material2d_meshes::<M>),
+                );
+        }
+    }
+}
+
+type DrawSpineDirectMaterial2d<M> = (
+    SetItemPipeline,
+    SetMesh2dViewBindGroup<0>,
+    SetMesh2dBindGroup<1>,
+    SetMaterial2dBindGroup<M, MATERIAL_2D_BIND_GROUP_INDEX>,
+    DrawSpineDirectMesh,
+);
+
+type DrawSpineDirectMaterial3d = (
+    SetItemPipeline,
+    SetMeshViewBindGroup<0>,
+    SetMeshViewBindingArrayBindGroup<1>,
+    SetMeshBindGroup<2>,
+    SetMaterialBindGroup<MATERIAL_3D_BIND_GROUP_INDEX>,
+    DrawSpineDirectMesh,
+);
+
+fn prepare_spine_direct_mesh_buffers(
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
+    mut buffers: ResMut<SpineDirectMeshBuffers>,
+    meshes: Query<(&MainEntity, &SpineDirectMesh)>,
+) {
+    buffers.prepare(&render_device, &render_queue, meshes.iter());
+}
+
+impl SpineDirectMeshBuffers {
+    fn prepare<'a>(
+        &mut self,
+        render_device: &RenderDevice,
+        render_queue: &RenderQueue,
+        meshes: impl IntoIterator<Item = (&'a MainEntity, &'a SpineDirectMesh)>,
+    ) {
+        self.meshes.clear();
+        self.vertices.clear();
+        self.indices.clear();
+
+        for (main_entity, mesh) in meshes {
+            self.pack(*main_entity, mesh);
+        }
+
+        let vertex_size = size_of_val(self.vertices.as_slice()) as u64;
+        let index_size = size_of_val(self.indices.as_slice()) as u64;
+
+        if vertex_size > self.vertex_capacity {
+            self.vertex_capacity = next_buffer_capacity(vertex_size);
+            self.vertex_buffer = Some(render_device.create_buffer(&BufferDescriptor {
+                label: Some("spine_direct_packed_vertex_buffer"),
+                size: self.vertex_capacity,
+                usage: BufferUsages::VERTEX | BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            }));
+        }
+        if index_size > self.index_capacity {
+            self.index_capacity = next_buffer_capacity(index_size);
+            self.index_buffer = Some(render_device.create_buffer(&BufferDescriptor {
+                label: Some("spine_direct_packed_index_buffer"),
+                size: self.index_capacity,
+                usage: BufferUsages::INDEX | BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            }));
+        }
+
+        if vertex_size > 0 {
+            let Some(buffer) = &self.vertex_buffer else {
+                error!("missing Spine direct vertex buffer after capacity check; skipping upload");
+                return;
+            };
+            render_queue.write_buffer(buffer, 0, bytemuck::cast_slice(self.vertices.as_slice()));
+        }
+
+        if index_size > 0 {
+            let Some(buffer) = &self.index_buffer else {
+                error!("missing Spine direct index buffer after capacity check; skipping upload");
+                return;
+            };
+            render_queue.write_buffer(buffer, 0, bytemuck::cast_slice(self.indices.as_slice()));
+        }
+    }
+
+    fn pack(&mut self, main_entity: MainEntity, mesh: &SpineDirectMesh) {
+        if mesh.vertices.is_empty() || mesh.indices.is_empty() {
+            return;
+        }
+
+        let Some(vertex_base) = i32::try_from(self.vertices.len()).ok() else {
+            error!(entity = ?main_entity, "too many packed Spine vertices; skipping mesh");
+            return;
+        };
+        let Some(index_start) = u32::try_from(self.indices.len()).ok() else {
+            error!(entity = ?main_entity, "too many packed Spine indices; skipping mesh");
+            return;
+        };
+        let Some(index_count) = u32::try_from(mesh.indices.len()).ok() else {
+            error!(entity = ?main_entity, "Spine mesh has too many indices; skipping mesh");
+            return;
+        };
+        let Some(index_end) = index_start.checked_add(index_count) else {
+            error!(entity = ?main_entity, "too many packed Spine indices; skipping mesh");
+            return;
+        };
+
+        self.vertices.extend_from_slice(&mesh.vertices);
+        self.indices.extend_from_slice(&mesh.indices);
+        self.meshes.insert(
+            main_entity,
+            PackedSpineDirectMesh {
+                indices: index_start..index_end,
+                vertex_base,
+            },
+        );
+    }
+}
+
+fn next_buffer_capacity(required: u64) -> u64 {
+    required
+        .max(MIN_BUFFER_CAPACITY)
+        .checked_next_power_of_two()
+        .unwrap_or(required)
+}
+
+fn queue_spine_direct_material2d_meshes<M: Material2d>(
+    render_materials: Res<RenderAssets<PreparedMaterial2d<M>>>,
+    render_material_instances: Res<RenderMaterial2dInstances<M>>,
+    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
+    views: Query<(&ExtractedView, &RenderVisibleEntities)>,
+    spine_meshes: Query<&SpineDirectMesh>,
+    draw_functions: Res<DrawFunctions<Transparent2d>>,
+) where
+    M::Data: PartialEq + Eq + Hash + Clone,
+{
+    let draw_function = draw_functions.read().id::<DrawSpineDirectMaterial2d<M>>();
+
+    for (view, view_visible_entities) in &views {
+        let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
+        else {
+            continue;
+        };
+
+        let Some(visible_entities) = view_visible_entities.get::<Mesh2d>() else {
+            continue;
+        };
+
+        for (_, main_entity) in &visible_entities.removed_entities {
+            transparent_phase.remove(Entity::PLACEHOLDER, *main_entity);
+        }
+
+        for (render_entity, visible_entity) in visible_entities.iter_visible() {
+            if !spine_meshes.contains(*render_entity) {
+                continue;
+            }
+            let Some(material_asset_id) = render_material_instances.get(visible_entity) else {
+                // Another registered direct material queue owns this mesh.
+                continue;
+            };
+
+            let Some(material_2d) = render_materials.get(*material_asset_id) else {
+                continue;
+            };
+            if material_2d.properties.alpha_mode != AlphaMode2d::Blend {
+                transparent_phase.remove(Entity::PLACEHOLDER, *visible_entity);
+                warn!(
+                    entity = ?visible_entity,
+                    material = std::any::type_name::<M>(),
+                    "Spine direct 2D rendering requires an alpha-blended Material2d; skipping mesh"
+                );
+                continue;
+            }
+            let Some(item) = transparent_phase
+                .items
+                .get_mut(&(Entity::PLACEHOLDER, *visible_entity))
+            else {
+                continue;
+            };
+            item.draw_function = draw_function;
+            item.batch_range = 0..1;
+            item.extra_index = PhaseItemExtraIndex::None;
+            item.indexed = true;
+        }
+    }
+}
+
+fn queue_spine_direct_material3d_meshes(
+    render_materials: Option<Res<ErasedRenderAssets<PreparedMaterial>>>,
+    render_material_instances: Option<Res<RenderMaterialInstances>>,
+    transparent_render_phases: Option<ResMut<ViewSortedRenderPhases<Transparent3d>>>,
+    views: Query<(&ExtractedView, &RenderVisibleEntities)>,
+    spine_meshes: Query<&SpineDirectMesh>,
+    draw_functions: Res<DrawFunctions<Transparent3d>>,
+) {
+    let Some(render_materials) = render_materials else {
+        return;
+    };
+    let Some(render_material_instances) = render_material_instances else {
+        return;
+    };
+    let Some(mut transparent_render_phases) = transparent_render_phases else {
+        return;
+    };
+    let draw_function = draw_functions.read().id::<DrawSpineDirectMaterial3d>();
+
+    for (view, view_visible_entities) in &views {
+        let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
+        else {
+            continue;
+        };
+
+        let Some(visible_entities) = view_visible_entities.get::<Mesh3d>() else {
+            continue;
+        };
+
+        for (_, main_entity) in &visible_entities.removed_entities {
+            transparent_phase.remove(Entity::PLACEHOLDER, *main_entity);
+        }
+
+        for (render_entity, visible_entity) in visible_entities.iter_visible() {
+            if !spine_meshes.contains(*render_entity) {
+                continue;
+            }
+            let Some(material_instance) = render_material_instances.instances.get(visible_entity)
+            else {
+                continue;
+            };
+            let Some(material) = render_materials.get(material_instance.asset_id) else {
+                continue;
+            };
+
+            if !matches!(
+                material.properties.render_phase_type,
+                RenderPhaseType::Transparent
+            ) {
+                transparent_phase.remove(Entity::PLACEHOLDER, *visible_entity);
+                warn!(
+                    entity = ?visible_entity,
+                    "Spine direct 3D rendering requires an alpha-blended Material; skipping mesh"
+                );
+                continue;
+            }
+
+            let Some(item) = transparent_phase
+                .items
+                .get_mut(&(Entity::PLACEHOLDER, *visible_entity))
+            else {
+                continue;
+            };
+            item.draw_function = draw_function;
+            item.batch_range = 0..1;
+            item.extra_index = PhaseItemExtraIndex::None;
+            item.indexed = true;
+        }
+    }
+}
+
+struct DrawSpineDirectMesh;
+
+impl<P: bevy::render::render_phase::PhaseItem> RenderCommand<P> for DrawSpineDirectMesh {
+    type Param = bevy::ecs::system::lifetimeless::SRes<SpineDirectMeshBuffers>;
+    type ViewQuery = ();
+    type ItemQuery = ();
+
+    fn render<'w>(
+        item: &P,
+        _view: (),
+        _entity: Option<()>,
+        buffers: bevy::ecs::system::SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let buffers = buffers.into_inner();
+        let Some(mesh) = buffers.meshes.get(&item.main_entity()) else {
+            return RenderCommandResult::Skip;
+        };
+        let (Some(vertex_buffer), Some(index_buffer)) =
+            (&buffers.vertex_buffer, &buffers.index_buffer)
+        else {
+            return RenderCommandResult::Skip;
+        };
+
+        pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+        pass.set_index_buffer(index_buffer.slice(..), IndexFormat::Uint16);
+        pass.draw_indexed(
+            mesh.indices.clone(),
+            mesh.vertex_base,
+            item.batch_range().clone(),
+        );
+
+        RenderCommandResult::Success
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,8 +375,8 @@ pub struct SpineSettings {
     /// This avoids per-frame mesh asset events and GPU mesh re-extraction for animated skeletons.
     /// Built-in 2D Spine materials are registered automatically by [`SpinePlugin`]; custom
     /// [`Material2d`](bevy::sprite_render::Material2d) materials also need
-    /// [`SpineDirectMaterial2dPlugin<M>`](SpineDirectMaterial2dPlugin). 3D Spine direct rendering
-    /// uses transparent Bevy PBR materials.
+    /// [`SpineDirectMaterial2dPlugin<M>`](SpineDirectMaterial2dPlugin). 3D Spine rendering
+    /// requires the `3d` cargo feature; direct 3D rendering uses transparent Bevy PBR materials.
     pub direct_rendering: bool,
 }
 
@@ -391,8 +391,10 @@ pub enum SpineMeshType {
     Mesh2D,
     /// Render meshes in 3D.
     ///
-    /// Requires a custom [`SpineMaterial`](`materials::SpineMaterial`) since the default materials
-    /// do not support 3D meshes.
+    /// Requires the `3d` cargo feature and a custom
+    /// [`SpineMaterial`](`materials::SpineMaterial`) since the default materials do not support 3D
+    /// meshes.
+    #[cfg(feature = "3d")]
     Mesh3D,
 }
 
@@ -969,6 +971,7 @@ fn spine_update_meshes(
 
                 let desired_3d_mesh = match mesh_type {
                     SpineMeshType::Mesh2D => None,
+                    #[cfg(feature = "3d")]
                     SpineMeshType::Mesh3D => Some(Mesh3d(spine_mesh.handle.clone())),
                 };
                 let mesh_components_changed = spine_2d_mesh != desired_2d_mesh.as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use bevy::{
     image::{ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor},
     mesh::{Indices, MeshVertexAttribute},
     prelude::*,
+    render::batching::NoAutomaticBatching,
     render::render_resource::{PrimitiveTopology, VertexFormat},
     sprite_render::Material2dPlugin,
 };
@@ -31,6 +32,7 @@ use textures::SpineTextureConfig;
 
 use crate::{
     assets::{AtlasLoader, SkeletonJsonLoader},
+    direct_render::SpineDirectMesh,
     materials::{DARK_COLOR_ATTRIBUTE, SHADER_HANDLE, SpineMaterialPlugin},
     rusty_spine::{
         AnimationStateData, BoneHandle, controller::SkeletonControllerSettings, draw::CullDirection,
@@ -39,6 +41,7 @@ use crate::{
 };
 
 pub use crate::{assets::*, crossfades::Crossfades, entity_sync::*, handle::*, rusty_spine::Color};
+pub use direct_render::SpineDirectMaterial2dPlugin;
 
 /// See [`rusty_spine`] docs for more info.
 pub use crate::rusty_spine::controller::SkeletonController;
@@ -124,6 +127,7 @@ impl Plugin for SpinePlugin {
             SpineMaterialPlugin::<SpineMultiplyPmaMaterial>::default(),
             SpineMaterialPlugin::<SpineScreenPmaMaterial>::default(),
         ))
+        .add_plugins(direct_render::SpineDirectRenderPlugin)
         .add_plugins(SpineSyncPlugin::first())
         .register_type::<Crossfades>()
         .register_type::<SkeletonDataHandle>()
@@ -366,6 +370,14 @@ pub struct SpineSettings {
     /// Defaults to `false` to reduce CPU work for large numbers of off-screen skeletons.
     /// Set this to `true` if off-screen meshes must stay fully up to date.
     pub update_meshes_when_invisible: bool,
+    /// Upload Spine geometry through a direct render path instead of mutating [`Mesh`] assets.
+    ///
+    /// This avoids per-frame mesh asset events and GPU mesh re-extraction for animated skeletons.
+    /// Built-in 2D Spine materials are registered automatically by [`SpinePlugin`]; custom
+    /// [`Material2d`](bevy::sprite_render::Material2d) materials also need
+    /// [`SpineDirectMaterial2dPlugin<M>`](SpineDirectMaterial2dPlugin). 3D Spine direct rendering
+    /// uses transparent Bevy PBR materials.
+    pub direct_rendering: bool,
 }
 
 #[derive(Component, Clone, Copy, Debug)]
@@ -377,8 +389,10 @@ pub(crate) struct SpineRenderOwner;
 pub enum SpineMeshType {
     /// Render meshes in 2D.
     Mesh2D,
-    /// Render meshes in 3D. Requires a custom [`SpineMaterial`](`materials::SpineMaterial`) since
-    /// the default materials do not support 3D meshes.
+    /// Render meshes in 3D.
+    ///
+    /// Requires a custom [`SpineMaterial`](`materials::SpineMaterial`) since the default materials
+    /// do not support 3D meshes.
     Mesh3D,
 }
 
@@ -406,6 +420,7 @@ impl Default for SpineSettings {
             mesh_type: SpineMeshType::Mesh2D,
             drawer: SpineDrawer::Combined,
             update_meshes_when_invisible: false,
+            direct_rendering: false,
         }
     }
 }
@@ -869,6 +884,8 @@ fn spine_update_meshes(
         Option<&mut Aabb>,
         Option<&Mesh2d>,
         Option<&Mesh3d>,
+        Option<&mut SpineDirectMesh>,
+        Has<NoAutomaticBatching>,
     )>,
     mesh_visibility_query: Query<&ViewVisibility, With<SpineMesh>>,
     mut commands: Commands,
@@ -905,6 +922,7 @@ fn spine_update_meshes(
             mesh_type,
             drawer,
             update_meshes_when_invisible,
+            direct_rendering,
             ..
         } = spine_mesh_type.cloned().unwrap_or(SpineSettings::default());
 
@@ -942,39 +960,67 @@ fn spine_update_meshes(
                 mut spine_mesh_aabb,
                 spine_2d_mesh,
                 spine_3d_mesh,
+                mut direct_mesh,
+                has_no_automatic_batching,
             )) = mesh_query.get_mut(child)
             {
-                macro_rules! apply_mesh {
-                    ($mesh:ident, $condition:expr, $attach:expr, $deattach:ty) => {
-                        if $condition {
-                            if !$mesh.is_some() {
-                                if let Ok(mut entity) = commands.get_entity(spine_mesh_entity) {
-                                    entity.insert($attach);
-                                }
-                            }
-                        } else {
-                            if $mesh.is_some() {
-                                if let Ok(mut entity) = commands.get_entity(spine_mesh_entity) {
-                                    entity.remove::<$deattach>();
-                                }
-                            }
-                        }
-                    };
+                let desired_2d_mesh =
+                    (mesh_type == SpineMeshType::Mesh2D).then(|| Mesh2d(spine_mesh.handle.clone()));
+
+                let desired_3d_mesh = match mesh_type {
+                    SpineMeshType::Mesh2D => None,
+                    SpineMeshType::Mesh3D => Some(Mesh3d(spine_mesh.handle.clone())),
+                };
+                let mesh_components_changed = spine_2d_mesh != desired_2d_mesh.as_ref()
+                    || spine_3d_mesh != desired_3d_mesh.as_ref()
+                    || has_no_automatic_batching != direct_rendering
+                    || (!direct_rendering && direct_mesh.is_some());
+
+                if mesh_components_changed
+                    && let Ok(mut entity) = commands.get_entity(spine_mesh_entity)
+                {
+                    if let Some(mesh_2d) = desired_2d_mesh {
+                        entity.insert(mesh_2d);
+                    } else {
+                        entity.remove::<Mesh2d>();
+                    }
+                    if let Some(mesh_3d) = desired_3d_mesh {
+                        entity.insert(mesh_3d);
+                    } else {
+                        entity.remove::<Mesh3d>();
+                    }
+                    if direct_rendering {
+                        entity.insert(NoAutomaticBatching);
+                    } else {
+                        entity.remove::<(SpineDirectMesh, NoAutomaticBatching)>();
+                    }
                 }
-                apply_mesh!(
-                    spine_2d_mesh,
-                    mesh_type == SpineMeshType::Mesh2D,
-                    Mesh2d(spine_mesh.handle.clone()),
-                    Mesh2d
-                );
-                apply_mesh!(
-                    spine_3d_mesh,
-                    mesh_type == SpineMeshType::Mesh3D,
-                    Mesh3d(spine_mesh.handle.clone()),
-                    Mesh3d
-                );
-                let Some(mut mesh) = meshes.get_mut(&spine_mesh.handle) else {
-                    continue;
+
+                if direct_rendering && mesh_components_changed {
+                    let Some(mut mesh) = meshes.get_mut(&spine_mesh.handle) else {
+                        warn!(
+                            "Spine mesh asset {:?} is missing; skipping direct mesh reset",
+                            spine_mesh.handle
+                        );
+                        continue;
+                    };
+                    // Direct rendering still uses the backing Mesh for bind groups and pipeline
+                    // specialization, so keep its static layout compatible with the direct vertex
+                    // buffer.
+                    empty_mesh(&mut mesh);
+                }
+
+                let mut mesh = if direct_rendering {
+                    None
+                } else {
+                    let Some(mesh) = meshes.get_mut(&spine_mesh.handle) else {
+                        warn!(
+                            "Spine mesh asset {:?} is missing; skipping mesh update",
+                            spine_mesh.handle
+                        );
+                        continue;
+                    };
+                    Some(mesh)
                 };
                 let mut empty = true;
                 'render: {
@@ -1065,19 +1111,50 @@ fn spine_update_meshes(
                     let spine_texture =
                         unsafe { &mut *(attachment_render_object as *mut SpineTexture) };
                     let texture_path = spine_texture.0.clone();
-                    let mut normals = vec![];
-                    for _ in 0..vertices.len() {
-                        normals.push([0., 0., 0.]);
+                    let mesh_updated = if direct_rendering {
+                        let mut next_direct_mesh = None;
+                        let updated = {
+                            let direct_mesh = if let Some(direct_mesh) = direct_mesh.as_deref_mut()
+                            {
+                                direct_mesh
+                            } else {
+                                next_direct_mesh.insert(SpineDirectMesh::default())
+                            };
+                            direct_mesh.write(
+                                spine_mesh_entity,
+                                &vertices,
+                                &indices,
+                                &uvs,
+                                &colors,
+                                &dark_colors,
+                            )
+                        };
+                        if updated
+                            && let Some(next_direct_mesh) = next_direct_mesh
+                            && let Ok(mut entity) = commands.get_entity(spine_mesh_entity)
+                        {
+                            entity.insert(next_direct_mesh);
+                        }
+                        updated
+                    } else if let Some(mesh) = mesh.as_deref_mut() {
+                        let normals = vec![[0., 0., 0.]; vertices.len()];
+                        mesh.insert_indices(Indices::U16(indices));
+                        mesh.insert_attribute(
+                            MeshVertexAttribute::new("Vertex_Position", 0, VertexFormat::Float32x2),
+                            vertices,
+                        );
+                        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+                        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+                        mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
+                        mesh.insert_attribute(DARK_COLOR_ATTRIBUTE, dark_colors);
+                        true
+                    } else {
+                        false
+                    };
+
+                    if !mesh_updated {
+                        break 'render;
                     }
-                    mesh.insert_indices(Indices::U16(indices));
-                    mesh.insert_attribute(
-                        MeshVertexAttribute::new("Vertex_Position", 0, VertexFormat::Float32x2),
-                        vertices,
-                    );
-                    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
-                    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
-                    mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
-                    mesh.insert_attribute(DARK_COLOR_ATTRIBUTE, dark_colors);
                     spine_mesh.state = SpineMeshState::Renderable {
                         info: SpineMaterialInfo {
                             slot_index,
@@ -1098,7 +1175,13 @@ fn spine_update_meshes(
                 }
                 if empty {
                     spine_mesh.state = SpineMeshState::Empty;
-                    empty_mesh(&mut mesh);
+                    if direct_rendering {
+                        if let Some(direct_mesh) = direct_mesh.as_deref_mut() {
+                            direct_mesh.clear();
+                        }
+                    } else if let Some(mesh) = mesh.as_deref_mut() {
+                        empty_mesh(mesh);
+                    }
                     write_spine_mesh_aabb(
                         &mut commands,
                         spine_mesh_entity,
@@ -1223,6 +1306,7 @@ fn adjust_spine_textures(
 
 mod assets;
 mod crossfades;
+mod direct_render;
 mod entity_sync;
 mod handle;
 #[cfg(feature = "ui")]
@@ -1235,8 +1319,9 @@ pub mod textures;
 pub mod prelude {
     pub use crate::{
         Crossfades, SkeletonController, SkeletonData, SkeletonDataHandle, Spine, SpineBone,
-        SpineEvent, SpineLoader, SpineMesh, SpineMeshState, SpinePlugin, SpineReadyEvent, SpineSet,
-        SpineSettings, SpineSync, SpineSyncSet, SpineSyncSystem, SpineSystem,
+        SpineDirectMaterial2dPlugin, SpineEvent, SpineLoader, SpineMesh, SpineMeshState,
+        SpinePlugin, SpineReadyEvent, SpineSet, SpineSettings, SpineSync, SpineSyncSet,
+        SpineSyncSystem, SpineSystem,
     };
     #[cfg(feature = "ui")]
     pub use crate::{SpineUiFit, SpineUiNode, SpineUiProxy, SpineUiReadyEvent, SpineUiSkeleton};


### PR DESCRIPTION
Adds a direct render path for animated Spine meshes. The direct path keeps Bevy's normal material and phase queueing, but uploads changing Spine geometry through shared render-world buffers instead of mutating `Mesh` assets every frame.

Changes:
- Adds extracted `SpineDirectMesh` geometry and packed GPU buffers.
- Adds direct 2D support for built-in Spine materials and custom `Material2d` materials.
- Reuses Bevy transparent phase items for direct 2D and direct 3D, then swaps in the direct draw command.
- Uses `u16` direct index buffers with `base_vertex`, plus rounded GPU buffer growth.
- Adds a `3d` cargo feature so PBR is only pulled when 3D Spine support is enabled.

The benchmark result is strong in the case this is meant to fix: lots of animated Spine meshes changing every frame. The old path spends most of its time extracting, preparing, and reallocating `RenderMesh` data. The direct path replaces that with one packed buffer upload.

Benchmark setup:

| Item | Value |
| --- | --- |
| Asset | `spineboy-pro.skel` with `spineboy-pma.atlas` |
| Build | release |
| Backend | Vulkan, RX 7800 XT |
| Window mode | `PresentMode::AutoNoVsync` |
| Stress setting | `update_meshes_when_invisible = true` |
| Direct run | temp benchmark forces `direct_rendering = true` |

2D full-frame stress run:

| Skeletons | Baseline mean | Direct mean | Change |
| ---: | ---: | ---: | ---: |
| 10 | 4.040 ms | 1.281 ms | 68.3% faster |
| 50 | 12.445 ms | 2.241 ms | 82.0% faster |
| 100 | 22.817 ms | 4.205 ms | 81.6% faster |
| 300 | 65.013 ms | 11.072 ms | 83.0% faster |
| 600 | 135.921 ms | 59.574 ms | 56.2% faster |
| 1200 | 290.284 ms | 42.406 ms | 85.4% faster |

Chrome trace at 1200 2D skeletons:

| Span | Baseline median | Direct median |
| --- | ---: | ---: |
| `extract_render_asset<RenderMesh>` | 52.104 ms | 0.011 ms |
| `prepare_assets<RenderMesh>` | 15.920 ms | 0.003 ms |
| `allocate_and_free_meshes` | 159.690 ms | 0.003 ms |
| `ExtractSchedule` | 54.434 ms | 5.714 ms |
| `prepare_spine_direct_mesh_buffers` | n/a | 7.079 ms |

Quick 3D sanity run:

| Skeletons | Baseline mean | Direct mean | Change |
| ---: | ---: | ---: | ---: |
| 10 | 4.428 ms | 1.904 ms | 57.0% faster |
| 50 | 12.792 ms | 2.993 ms | 76.6% faster |
| 100 | 23.206 ms | 4.511 ms | 80.6% faster |
| 300 | 72.319 ms | 13.645 ms | 81.1% faster |
| 600 | 139.609 ms | 25.273 ms | 81.9% faster |

Validation:
- `cargo +nightly-2026-05-09 fmt --check`
- `cargo +nightly-2026-05-09 clippy --lib --no-default-features`
- `cargo +nightly-2026-05-09 clippy --all-features --all-targets`
- `cargo +nightly-2026-05-09 test --lib --no-default-features`
- `cargo +nightly-2026-05-09 test --all-features --all-targets`
- `cargo +nightly-2026-05-09 tree -e normal -i bevy_pbr --no-default-features` prints nothing

The benchmark is a stress scene, not a promise that every Spine scene gets the same frame-time drop. It does show the direct path removes the expensive part of the current animated-mesh pipeline.
